### PR TITLE
Dbl prec history

### DIFF
--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -59,8 +59,8 @@
   <!-- =========================== -->
 
   <entry id="ice_ic" skip_default_entry="true">
-    <type>char</type> 
-    <category>setup</category> 
+    <type>char</type>
+    <category>setup</category>
     <group>setup_nml</group>
     <desc>
       Method of ice cover initialization.
@@ -79,8 +79,8 @@
   </entry>
 
   <entry id="pointer_file">
-    <type>char</type> 
-    <category>setup</category> 
+    <type>char</type>
+    <category>setup</category>
     <group>setup_nml</group>
     <desc>
       restart pointer filename
@@ -103,8 +103,8 @@
   </entry>
 
   <entry id="restart_format">
-    <type>char</type> 
-    <category>setup</category> 
+    <type>char</type>
+    <category>setup</category>
     <group>setup_nml</group>
     <desc>
       Restart file format. bin, nc, or pio
@@ -116,8 +116,8 @@
   </entry>
 
   <entry id="restart_ext">
-    <type>logical</type> 
-    <category>setup</category> 
+    <type>logical</type>
+    <category>setup</category>
     <group>setup_nml</group>
     <desc>
       Restart with extended grid
@@ -136,6 +136,18 @@
     </desc>
     <values>
       <value>unknown</value>
+    </values>
+  </entry>
+
+  <entry id="history_precision">
+    <type>integer</type>
+    <category>setup</category>
+    <group>setup_nml</group>
+    <desc>
+      history precision (4 or 8)
+    </desc>
+    <values>
+      <value>4</value>
     </values>
   </entry>
 
@@ -169,11 +181,11 @@
   </entry>
 
   <entry id="year_init">
-    <type>integer</type>  
-    <category>setup</category> 
+    <type>integer</type>
+    <category>setup</category>
     <group>setup_nml</group>
     <desc>
-      Initial year. 
+      Initial year.
     </desc>
     <values>
       <value>1</value>
@@ -182,11 +194,11 @@
   </entry>
 
   <entry id="ndtd">
-    <type>integer</type>  
-    <category>setup</category> 
+    <type>integer</type>
+    <category>setup</category>
     <group>setup_nml</group>
     <desc>
-      number of dynamic time steps per thermodynamic time step 
+      number of dynamic time steps per thermodynamic time step
     </desc>
     <values>
       <value>1</value>
@@ -200,25 +212,25 @@
   <!-- =========================== -->
 
   <entry id="histfreq">
-    <type>char(10)</type>  
-    <category>setup</category> 
+    <type>char(10)</type>
+    <category>setup</category>
     <group>setup_nml</group>
     <desc>
-      frequency of history output (once per 1,h,d,m,y) 
+      frequency of history output (once per 1,h,d,m,y)
     </desc>
     <values>
-      <value>m,x,x,x,x</value> 
+      <value>m,x,x,x,x</value>
       <value hgrid="ar9v3">m,d,h,x,x</value>
       <value hgrid="ar9v4">m,d,h,x,x</value>
     </values>
   </entry>
 
   <entry id="dumpfreq">
-    <type>char</type>  
-    <category>setup</category> 
+    <type>char</type>
+    <category>setup</category>
     <group>setup_nml</group>
     <desc>
-      frequency of restart output (once per 1,h,d,m,y) 
+      frequency of restart output (once per 1,h,d,m,y)
     </desc>
     <values>
       <value>x</value>
@@ -226,8 +238,8 @@
   </entry>
 
   <entry id="histfreq_n">
-    <type>integer(5)</type>  
-    <category>setup</category> 
+    <type>integer(5)</type>
+    <category>setup</category>
     <group>setup_nml</group>
     <desc>
       frequency of history output (10 = once per 10 h,d,m,y)
@@ -238,8 +250,8 @@
   </entry>
 
   <entry id="hist_avg">
-    <type>logical</type>  
-    <category>setup</category> 
+    <type>logical</type>
+    <category>setup</category>
     <group>setup_nml</group>
     <desc>
       if true, write time-averages (not snapshots)
@@ -250,8 +262,8 @@
   </entry>
 
   <entry id="write_ic">
-    <type>logical</type>  
-    <category>setup</category> 
+    <type>logical</type>
+    <category>setup</category>
     <group>setup_nml</group>
     <desc>
       if true, write initial state
@@ -266,8 +278,8 @@
   <!-- =========================== -->
 
   <entry id="diagfreq">
-    <type>integer</type>  
-    <category>setup</category> 
+    <type>integer</type>
+    <category>setup</category>
     <group>setup_nml</group>
     <desc>
       diagnostic output frequency (10 = once per 10 dt)
@@ -278,8 +290,8 @@
   </entry>
 
   <entry id="print_global">
-    <type>logical</type>  
-    <category>setup</category> 
+    <type>logical</type>
+    <category>setup</category>
     <group>setup_nml</group>
     <desc>
       logical to print out diagnostics for global output
@@ -290,8 +302,8 @@
   </entry>
 
   <entry id="print_points">
-    <type>logical</type>  
-    <category>setup</category> 
+    <type>logical</type>
+    <category>setup</category>
     <group>setup_nml</group>
     <desc>
       logical to print out diagnostics for point data
@@ -302,8 +314,8 @@
   </entry>
 
   <entry id="bfbflag" modify_via_xml="BFBFLAG">
-    <type>logical</type>  
-    <category>setup</category> 
+    <type>logical</type>
+    <category>setup</category>
     <group>setup_nml</group>
     <desc>
       logical to control bit-for-bit computations
@@ -314,8 +326,8 @@
   </entry>
 
   <entry id="lonpnt">
-    <type>real(2)</type>  
-    <category>setup</category> 
+    <type>real(2)</type>
+    <category>setup</category>
     <group>setup_nml</group>
     <desc>
       list of longitudes for point diagnostics
@@ -326,8 +338,8 @@
   </entry>
 
   <entry id="latpnt">
-    <type>real(2)</type>  
-    <category>setup</category> 
+    <type>real(2)</type>
+    <category>setup</category>
     <group>setup_nml</group>
     <desc>
       list of latitudes for point diagnostics
@@ -338,8 +350,8 @@
   </entry>
 
   <entry id="lcdf64">
-    <type>logical</type>  
-    <category>setup</category> 
+    <type>logical</type>
+    <category>setup</category>
     <group>setup_nml</group>
     <desc>
       64 bit offset
@@ -354,41 +366,41 @@
   <!-- =========================== -->
 
   <entry id="grid_format">
-    <type>char</type>  
-    <category>grid</category> 
+    <type>char</type>
+    <category>grid</category>
     <group>grid_nml</group>
     <desc>
       file format ('bin'=binary or 'nc'=netcdf)
     </desc>
     <valid_values>bin,nc</valid_values>
     <values>
-      <value>bin</value> 
+      <value>bin</value>
       <value cice_mode="prescribed">nc</value>
     </values>
   </entry>
 
   <entry id="grid_type">
-    <type>char</type>  
-    <category>grid</category> 
+    <type>char</type>
+    <category>grid</category>
     <group>grid_nml</group>
     <desc>
       type of grid
     </desc>
     <valid_values>displaced_pole,tripole,panarctic,latlon,rectangular</valid_values>
     <values>
-      <value>displaced_pole</value> 
+      <value>displaced_pole</value>
       <value cice_mode="prescribed">latlon</value>
-      <value hgrid="tx0.1v2">tripole</value> 
-      <value hgrid="tx0.1v3">tripole</value> 
-      <value hgrid="tx1v1">tripole</value> 
-      <value hgrid="ar9v3">regional</value> 
-      <value hgrid="ar9v4">regional</value> 
+      <value hgrid="tx0.1v2">tripole</value>
+      <value hgrid="tx0.1v3">tripole</value>
+      <value hgrid="tx1v1">tripole</value>
+      <value hgrid="ar9v3">regional</value>
+      <value hgrid="ar9v4">regional</value>
     </values>
   </entry>
 
   <entry id="grid_file">
-    <type>char</type>  
-    <category>grid</category> 
+    <type>char</type>
+    <category>grid</category>
     <group>grid_nml</group>
     <input_pathname>abs</input_pathname>
     <desc>
@@ -396,21 +408,21 @@
     </desc>
     <values>
       <value cice_mode="prescribed">$ICE_DOMAIN_PATH/$ICE_DOMAIN_FILE</value>
-      <value hgrid="gx1v6">$DIN_LOC_ROOT/ocn/pop/gx1v6/grid/horiz_grid_20010402.ieeer8</value> 
-      <value hgrid="gx1v7">$DIN_LOC_ROOT/ocn/pop/gx1v7/grid/horiz_grid_20010402.ieeer8</value> 
-      <value hgrid="gx3v7">$DIN_LOC_ROOT/ocn/pop/gx3v7/grid/horiz_grid_20030806.ieeer8</value> 
-      <value hgrid="tx0.1v2">$DIN_LOC_ROOT/ocn/pop/tx0.1v2/grid/horiz_grid_200709.ieeer8</value> 
-      <value hgrid="tx0.1v3">$DIN_LOC_ROOT/ocn/pop/tx0.1v3/grid/horiz_grid_200709.ieeer8</value> 
+      <value hgrid="gx1v6">$DIN_LOC_ROOT/ocn/pop/gx1v6/grid/horiz_grid_20010402.ieeer8</value>
+      <value hgrid="gx1v7">$DIN_LOC_ROOT/ocn/pop/gx1v7/grid/horiz_grid_20010402.ieeer8</value>
+      <value hgrid="gx3v7">$DIN_LOC_ROOT/ocn/pop/gx3v7/grid/horiz_grid_20030806.ieeer8</value>
+      <value hgrid="tx0.1v2">$DIN_LOC_ROOT/ocn/pop/tx0.1v2/grid/horiz_grid_200709.ieeer8</value>
+      <value hgrid="tx0.1v3">$DIN_LOC_ROOT/ocn/pop/tx0.1v3/grid/horiz_grid_200709.ieeer8</value>
       <value hgrid="tx1v1">$DIN_LOC_ROOT/ocn/pop/tx1v1/grid/horiz_grid_20050510.ieeer8</value>
       <value hgrid="ar9v3">$DIN_LOC_ROOT/ice/cice/ar9v3_20101118.grid</value>
       <value hgrid="ar9v4">$DIN_LOC_ROOT/ice/cice/ar9v3_20101118.grid</value>
-      <value hgrid="us20">$DIN_LOC_ROOT/ice/cice/domain.ocn.us20.20110426.nc</value> 
+      <value hgrid="us20">$DIN_LOC_ROOT/ice/cice/domain.ocn.us20.20110426.nc</value>
     </values>
   </entry>
 
   <entry id="kmt_file">
-    <type>char</type>  
-    <category>grid</category> 
+    <type>char</type>
+    <category>grid</category>
     <group>grid_nml</group>
     <input_pathname>abs</input_pathname>
     <desc>
@@ -418,21 +430,21 @@
     </desc>
     <values>
       <value cice_mode="prescribed">$ICE_DOMAIN_PATH/$ICE_DOMAIN_FILE</value>
-      <value hgrid="gx1v6">$DIN_LOC_ROOT/ocn/pop/gx1v6/grid/topography_20090204.ieeei4</value> 
-      <value hgrid="gx1v7">$DIN_LOC_ROOT/ocn/pop/gx1v7/grid/topography_20161215.ieeei4</value> 
-      <value hgrid="gx3v7">$DIN_LOC_ROOT/ocn/pop/gx3v7/grid/topography_20100105.ieeei4</value> 
-      <value hgrid="tx0.1v2">$DIN_LOC_ROOT/ocn/pop/tx0.1v2/grid/topography_200709.ieeei4</value> 
-      <value hgrid="tx0.1v3">$DIN_LOC_ROOT/ocn/pop/tx0.1v3/grid/topography_20170718.ieeei4</value> 
+      <value hgrid="gx1v6">$DIN_LOC_ROOT/ocn/pop/gx1v6/grid/topography_20090204.ieeei4</value>
+      <value hgrid="gx1v7">$DIN_LOC_ROOT/ocn/pop/gx1v7/grid/topography_20161215.ieeei4</value>
+      <value hgrid="gx3v7">$DIN_LOC_ROOT/ocn/pop/gx3v7/grid/topography_20100105.ieeei4</value>
+      <value hgrid="tx0.1v2">$DIN_LOC_ROOT/ocn/pop/tx0.1v2/grid/topography_200709.ieeei4</value>
+      <value hgrid="tx0.1v3">$DIN_LOC_ROOT/ocn/pop/tx0.1v3/grid/topography_20170718.ieeei4</value>
       <value hgrid="tx1v1">$DIN_LOC_ROOT/ocn/pop/tx1v1/grid/topography_20050510.ieeei4</value>
       <value hgrid="ar9v3">$DIN_LOC_ROOT/ocn/pop/ar9v3/grid/kmt.ar9v3.ocn.ChanBarrier.20100622.ieeei4</value>
       <value hgrid="ar9v4">$DIN_LOC_ROOT/ice/cice/ar9v3_20110106.kmt</value>
-      <value hgrid="us20">$DIN_LOC_ROOT/ice/cice/domain.ocn.us20.20110426.nc</value> 
+      <value hgrid="us20">$DIN_LOC_ROOT/ice/cice/domain.ocn.us20.20110426.nc</value>
     </values>
   </entry>
 
   <entry id="kcatbound">
-    <type>integer</type>  
-    <category>grid</category> 
+    <type>integer</type>
+    <category>grid</category>
     <group>grid_nml</group>
     <desc>
       category boundary formula (0 = old, 1 = new)
@@ -443,8 +455,8 @@
   </entry>
 
   <entry id="gridcpl_file">
-    <type>char</type>  
-    <category>grid</category> 
+    <type>char</type>
+    <category>grid</category>
     <group>grid_nml</group>
     <input_pathname>abs</input_pathname>
     <desc>
@@ -461,8 +473,8 @@
   <!-- =========================== -->
 
   <entry id="processor_shape" modify_via_xml="CICE_DECOMPSETTING">
-    <type>char</type>  
-    <category>decomp</category> 
+    <type>char</type>
+    <category>decomp</category>
     <group>domain_nml</group>
     <desc>
       processor shape
@@ -474,8 +486,8 @@
   </entry>
 
   <entry id="distribution_type" modify_via_xml="CICE_DECOMPTYPE">
-    <type>char</type>  
-    <category>decomp</category> 
+    <type>char</type>
+    <category>decomp</category>
     <group>domain_nml</group>
     <desc>
       method to use for distributing blocks among processors
@@ -486,8 +498,8 @@
   </entry>
 
   <entry id="distribution_wght">
-    <type>char</type>  
-    <category>decomp</category> 
+    <type>char</type>
+    <category>decomp</category>
     <group>domain_nml</group>
     <desc>
       method to use for distributing blocks
@@ -502,8 +514,8 @@
   </entry>
 
   <entry id="ew_boundary_type">
-    <type>char</type>  
-    <category>decomp</category> 
+    <type>char</type>
+    <category>decomp</category>
     <group>domain_nml</group>
     <desc>
       type of boundary in logical east-west dir
@@ -515,8 +527,8 @@
   </entry>
 
   <entry id="ns_boundary_type">
-    <type>char</type>  
-    <category>decomp</category> 
+    <type>char</type>
+    <category>decomp</category>
     <group>domain_nml</group>
     <desc>
     </desc>
@@ -530,8 +542,8 @@
   </entry>
 
   <entry id="maskhalo_dyn">
-    <type>logical</type>  
-    <category>decomp</category> 
+    <type>logical</type>
+    <category>decomp</category>
     <group>domain_nml</group>
     <desc>
       turn on masked halos in subcycling
@@ -542,8 +554,8 @@
   </entry>
 
   <entry id="maskhalo_remap">
-    <type>logical</type>  
-    <category>decomp</category> 
+    <type>logical</type>
+    <category>decomp</category>
     <group>domain_nml</group>
     <desc>
       turn on masked halos in tracer halo update in remap
@@ -554,8 +566,8 @@
   </entry>
 
   <entry id="maskhalo_bound">
-    <type>logical</type>  
-    <category>decomp</category> 
+    <type>logical</type>
+    <category>decomp</category>
     <group>domain_nml</group>
     <desc>
       turn on masked halos in state bound
@@ -570,8 +582,8 @@
   <!-- =========================== -->
 
   <entry id="tr_iage">
-    <type>logical</type>  
-    <category>tracers</category> 
+    <type>logical</type>
+    <category>tracers</category>
     <group>tracer_nml</group>
     <desc>
       Ice age tracer.
@@ -586,8 +598,8 @@
   </entry>
 
   <entry id="restart_age">
-    <type>logical</type>  
-    <category>tracers</category> 
+    <type>logical</type>
+    <category>tracers</category>
     <group>tracer_nml</group>
     <desc>
       Ice age restart from file.
@@ -598,8 +610,8 @@
   </entry>
 
   <entry id="tr_fy">
-    <type>logical</type>  
-    <category>tracers</category> 
+    <type>logical</type>
+    <category>tracers</category>
     <group>tracer_nml</group>
     <desc>
       FY area tracer.
@@ -614,8 +626,8 @@
   </entry>
 
   <entry id="restart_fy">
-    <type>logical</type>  
-    <category>tracers</category> 
+    <type>logical</type>
+    <category>tracers</category>
     <group>tracer_nml</group>
     <desc>
       FY area restart from file.
@@ -626,8 +638,8 @@
   </entry>
 
   <entry id="tr_lvl">
-    <type>logical</type>  
-    <category>tracers</category> 
+    <type>logical</type>
+    <category>tracers</category>
     <group>tracer_nml</group>
     <desc>
       lvl tracer.
@@ -642,8 +654,8 @@
   </entry>
 
   <entry id="restart_lvl">
-    <type>logical</type>  
-    <category>tracers</category> 
+    <type>logical</type>
+    <category>tracers</category>
     <group>tracer_nml</group>
     <desc>
       lvl restart from file.
@@ -654,8 +666,8 @@
   </entry>
 
   <entry id="tr_pond_cesm">
-    <type>logical</type>  
-    <category>tracers</category> 
+    <type>logical</type>
+    <category>tracers</category>
     <group>tracer_nml</group>
     <desc>
       Pond volume tracer.
@@ -670,8 +682,8 @@
   </entry>
 
   <entry id="restart_pond_cesm">
-    <type>logical</type>  
-    <category>tracers</category> 
+    <type>logical</type>
+    <category>tracers</category>
     <group>tracer_nml</group>
     <desc>
       Pond volume restart from file.
@@ -682,8 +694,8 @@
   </entry>
 
   <entry id="tr_pond_topo">
-    <type>logical</type>  
-    <category>tracers</category> 
+    <type>logical</type>
+    <category>tracers</category>
     <group>tracer_nml</group>
     <desc>
       Pond topo tracer.
@@ -694,8 +706,8 @@
   </entry>
 
   <entry id="restart_pond_topo">
-    <type>logical</type>  
-    <category>tracers</category> 
+    <type>logical</type>
+    <category>tracers</category>
     <group>tracer_nml</group>
     <desc>
       Pond topo restart from file.
@@ -708,8 +720,8 @@
   </entry>
 
   <entry id="tr_pond_lvl">
-    <type>logical</type>  
-    <category>tracers</category> 
+    <type>logical</type>
+    <category>tracers</category>
     <group>tracer_nml</group>
     <desc>
       Pond lvl tracer.
@@ -724,8 +736,8 @@
   </entry>
 
   <entry id="restart_pond_lvl">
-    <type>logical</type>  
-    <category>tracers</category> 
+    <type>logical</type>
+    <category>tracers</category>
     <group>tracer_nml</group>
     <desc>
       Pond lvl restart from file.
@@ -736,8 +748,8 @@
   </entry>
 
   <entry id="tr_aero">
-    <type>logical</type>  
-    <category>tracers</category> 
+    <type>logical</type>
+    <category>tracers</category>
     <group>tracer_nml</group>
     <desc>
       Aerosol tracers.
@@ -749,8 +761,8 @@
   </entry>
 
   <entry id="restart_aero">
-    <type>logical</type>  
-    <category>tracers</category> 
+    <type>logical</type>
+    <category>tracers</category>
     <group>tracer_nml</group>
     <desc>
       Aerosol restart from file.
@@ -761,8 +773,8 @@
   </entry>
 
   <entry id="tr_iso">
-    <type>logical</type>  
-    <category>tracers</category> 
+    <type>logical</type>
+    <category>tracers</category>
     <group>tracer_nml</group>
     <desc>
       Aerosol tracers.
@@ -774,8 +786,8 @@
   </entry>
 
   <entry id="restart_iso">
-    <type>logical</type>  
-    <category>tracers</category> 
+    <type>logical</type>
+    <category>tracers</category>
     <group>tracer_nml</group>
     <desc>
       Aerosol restart from file.
@@ -790,120 +802,120 @@
   <!-- =========================== -->
 
   <entry id="kitd">
-    <type>integer</type>  
-    <category>parameterizations</category> 
+    <type>integer</type>
+    <category>parameterizations</category>
     <group>thermo_nml</group>
     <desc>
       type of itd conversions (0 = delta, 1 = linear)
     </desc>
     <valid_values>0,1</valid_values>
     <values>
-      <value>1</value> 
-      <value cice_mode='prescribed'>0</value> 
-      <value cice_mode='thermo_only'>0</value> 
+      <value>1</value>
+      <value cice_mode='prescribed'>0</value>
+      <value cice_mode='thermo_only'>0</value>
     </values>
   </entry>
 
   <entry id="ktherm">
-    <type>integer</type>  
-    <category>parameterizations</category> 
+    <type>integer</type>
+    <category>parameterizations</category>
     <group>thermo_nml</group>
     <desc>
       type of thermodynamics (0=zero-layer, 1=bitz/lipscomb, 2=mushy)
     </desc>
     <valid_values>0,1,2</valid_values>
     <values>
-      <value>2</value> 
-      <value phys="cice4">1</value> 
-      <value hgrid="ar9v3">1</value> 
-      <value hgrid="ar9v4">1</value> 
+      <value>2</value>
+      <value phys="cice4">1</value>
+      <value hgrid="ar9v3">1</value>
+      <value hgrid="ar9v4">1</value>
     </values>
   </entry>
 
   <entry id="conduct">
-    <type>char</type>  
-    <category>parameterizations</category> 
+    <type>char</type>
+    <category>parameterizations</category>
     <group>thermo_nml</group>
     <desc>
       conductivity (MU71, bubbly)
     </desc>
     <valid_values>MU71,bubbly</valid_values>
     <values>
-      <value>MU71</value> 
-      <value hgrid="ar9v3">bubbly</value> 
-      <value hgrid="ar9v4">bubbly</value> 
+      <value>MU71</value>
+      <value hgrid="ar9v3">bubbly</value>
+      <value hgrid="ar9v4">bubbly</value>
     </values>
   </entry>
 
   <entry id="a_rapid_mode">
-    <type>real</type>  
+    <type>real</type>
     <category>parameterizations</category>
     <group>thermo_nml</group>
     <desc>
       brine channel diameter (m)
     </desc>
     <values>
-      <value>0.5e-03</value> 
+      <value>0.5e-03</value>
     </values>
   </entry>
 
   <entry id="rac_rapid_mode">
-    <type>real</type>  
+    <type>real</type>
     <category>parameterizations</category>
     <group>thermo_nml</group>
     <desc>
       critical Rayleigh number
     </desc>
     <values>
-      <value>10</value> 
+      <value>10</value>
     </values>
   </entry>
 
   <entry id="aspect_rapid_mode">
-    <type>real</type>  
+    <type>real</type>
     <category>parameterizations</category>
     <group>thermo_nml</group>
     <desc>
       brine convection aspect ratio
     </desc>
     <values>
-      <value>1.0</value> 
+      <value>1.0</value>
     </values>
   </entry>
 
   <entry id="dsdt_slow_mode">
-    <type>real</type>  
+    <type>real</type>
     <category>parameterizations</category>
     <group>thermo_nml</group>
     <desc>
       drainage strength parameter m/s/K
     </desc>
     <values>
-      <value>-1.5e-07</value> 
+      <value>-1.5e-07</value>
     </values>
   </entry>
 
   <entry id="phi_c_slow_mode">
-    <type>real</type>  
+    <type>real</type>
     <category>parameterizations</category>
     <group>thermo_nml</group>
     <desc>
       critical liquid fraction between 0 and 1
     </desc>
     <values>
-      <value>0.05</value> 
+      <value>0.05</value>
     </values>
   </entry>
 
   <entry id="phi_i_mushy">
-    <type>real</type>  
+    <type>real</type>
     <category>parameterizations</category>
     <group>thermo_nml</group>
     <desc>
       solid fraction at lower boundary between 0 and 1
     </desc>
     <values>
-      <value>0.85</value> 
+      <value>0.85</value>
     </values>
   </entry>
 
@@ -912,51 +924,51 @@
   <!-- =========================== -->
 
   <entry id="kdyn">
-    <type>integer</type>  
-    <category>parameterizations</category> 
+    <type>integer</type>
+    <category>parameterizations</category>
     <group>dynamics_nml</group>
     <desc>
       type of dynamics (0=off, 1=evp, 2=eap)
     </desc>
     <valid_values>0,1,2</valid_values>
     <values>
-      <value>1</value> 
-      <value  cice_mode='prescribed'>0</value> 
-      <value  cice_mode='thermo_only'>0</value> 
-      <value  hgrid="ar9v3">2</value> 
-      <value  hgrid="ar9v4">2</value> 
+      <value>1</value>
+      <value  cice_mode='prescribed'>0</value>
+      <value  cice_mode='thermo_only'>0</value>
+      <value  hgrid="ar9v3">2</value>
+      <value  hgrid="ar9v4">2</value>
     </values>
   </entry>
 
   <entry id="revised_evp">
-    <type>logical</type>  
-    <category>parameterizations</category> 
+    <type>logical</type>
+    <category>parameterizations</category>
     <group>dynamics_nml</group>
     <desc>
       use revised EVP formulation
     </desc>
     <values>
-      <value hgrid="ar9v3">.false.</value> 
-      <value hgrid="ar9v4">.false.</value> 
-      <value>.false.</value> 
+      <value hgrid="ar9v3">.false.</value>
+      <value hgrid="ar9v4">.false.</value>
+      <value>.false.</value>
     </values>
   </entry>
 
   <entry id="ndte">
-    <type>integer</type>  
-    <category>parameterizations</category> 
+    <type>integer</type>
+    <category>parameterizations</category>
     <group>dynamics_nml</group>
     <desc>
       subcycles per dynamics timestep
     </desc>
     <values>
-      <value> 120 </value> 
+      <value> 120 </value>
     </values>
   </entry>
 
   <entry id="advection">
-    <type>char</type>  
-    <category>parameterizations</category> 
+    <type>char</type>
+    <category>parameterizations</category>
     <group>dynamics_nml</group>
     <desc>
       incremental remapping transport scheme, remap or upwind
@@ -968,23 +980,23 @@
   </entry>
 
   <entry id="kstrength">
-    <type>integer</type>  
-    <category>parameterizations</category> 
+    <type>integer</type>
+    <category>parameterizations</category>
     <group>dynamics_nml</group>
     <desc>
       ice strength formulation (0=Hibler 79, 1=Rothrock 75)
     </desc>
     <valid_values>0,1</valid_values>
     <values>
-      <value>1</value> 
-      <value cice_mode='prescribed'>0</value> 
-      <value cice_mode='thermo_only'>0</value> 
+      <value>1</value>
+      <value cice_mode='prescribed'>0</value>
+      <value cice_mode='thermo_only'>0</value>
     </values>
   </entry>
 
   <entry id="krdg_partic">
-    <type>integer</type>  
-    <category>parameterizations</category> 
+    <type>integer</type>
+    <category>parameterizations</category>
     <group>dynamics_nml</group>
     <desc>
       ridging participation function (0=Thorndike et al 75, 1=new participation )
@@ -996,8 +1008,8 @@
   </entry>
 
   <entry id="krdg_redist">
-    <type>integer</type>  
-    <category>parameterizations</category> 
+    <type>integer</type>
+    <category>parameterizations</category>
     <group>dynamics_nml</group>
     <desc>
       ridging distribution function (0=old Hibler 80, 1=new redistribution)
@@ -1009,8 +1021,8 @@
   </entry>
 
   <entry id="mu_rdg">
-    <type>real</type>  
-    <category>parameterizations</category> 
+    <type>real</type>
+    <category>parameterizations</category>
     <group>dynamics_nml</group>
     <desc>
       e-folding scale of ridged ice
@@ -1023,8 +1035,8 @@
   </entry>
 
   <entry id="cf">
-    <type>real</type>  
-    <category>parameterizations</category> 
+    <type>real</type>
+    <category>parameterizations</category>
     <group>dynamics_nml</group>
     <desc>
       Ratio of ridging work to PE change in ridging
@@ -1041,8 +1053,8 @@
   <!-- =========================== -->
 
   <entry id="shortwave">
-    <type>char</type>  
-    <category>swrad</category> 
+    <type>char</type>
+    <category>swrad</category>
     <group>shortwave_nml</group>
     <desc>
       shortwave method, 'default' ('ccsm3') or 'dEdd'
@@ -1054,11 +1066,11 @@
   </entry>
 
   <entry id="albedo_type">
-    <type>char</type>  
-    <category>albedos</category> 
+    <type>char</type>
+    <category>albedos</category>
     <group>shortwave_nml</group>
     <desc>
-      albedo parameterization, 'default' ('ccsm3') or 'constant' 
+      albedo parameterization, 'default' ('ccsm3') or 'constant'
     </desc>
     <valid_values>default,constant</valid_values>
     <values>
@@ -1067,60 +1079,60 @@
   </entry>
 
   <entry id="albicev">
-    <type>real</type>  
-    <category>albedos</category> 
+    <type>real</type>
+    <category>albedos</category>
     <group>shortwave_nml</group>
     <desc>
       visible ice albedo for h gt ahmax
     </desc>
     <values>
-      <value>0.75</value> 
-      <value hgrid="gx3v7">0.68</value> 
+      <value>0.75</value>
+      <value hgrid="gx3v7">0.68</value>
     </values>
   </entry>
 
   <entry id="albicei">
-    <type>real</type>  
-    <category>albedos</category> 
+    <type>real</type>
+    <category>albedos</category>
     <group>shortwave_nml</group>
     <desc>
       near-ir ice albedo for h gt ahmax
     </desc>
     <values>
-      <value>0.45</value> 
-      <value hgrid="gx3v7">0.30</value> 
+      <value>0.45</value>
+      <value hgrid="gx3v7">0.30</value>
     </values>
   </entry>
 
   <entry id="albsnowv">
-    <type>real</type>  
-    <category>albedos</category> 
+    <type>real</type>
+    <category>albedos</category>
     <group>shortwave_nml</group>
     <desc>
       cold snow albedo, visible
     </desc>
     <values>
-      <value>0.98</value> 
-      <value hgrid="gx3v7">0.91</value> 
+      <value>0.98</value>
+      <value hgrid="gx3v7">0.91</value>
     </values>
   </entry>
 
   <entry id="albsnowi">
-    <type>real</type>  
-    <category>albedos</category> 
+    <type>real</type>
+    <category>albedos</category>
     <group>shortwave_nml</group>
     <desc>
       cold snow albedo, near IR
     </desc>
     <values>
-      <value>0.73</value> 
-      <value hgrid="gx3v7">0.63</value> 
+      <value>0.73</value>
+      <value hgrid="gx3v7">0.63</value>
     </values>
   </entry>
 
   <entry id="ahmax">
-    <type>real</type>  
-    <category>swrad</category> 
+    <type>real</type>
+    <category>swrad</category>
     <group>shortwave_nml</group>
     <desc>
       albedo is constant above this thickness
@@ -1131,8 +1143,8 @@
   </entry>
 
   <entry id="r_ice">
-    <type>real</type>  
-    <category>swrad</category> 
+    <type>real</type>
+    <category>swrad</category>
     <group>shortwave_nml</group>
     <desc>
       tuning parameter for delta-eddington shortwave for sea ice albedo
@@ -1143,8 +1155,8 @@
   </entry>
 
   <entry id="r_pnd">
-    <type>real</type>  
-    <category>swrad</category> 
+    <type>real</type>
+    <category>swrad</category>
     <group>shortwave_nml</group>
     <desc>
       tuning parameter for delta-eddington shortwave for ponded sea ice albedo
@@ -1155,8 +1167,8 @@
   </entry>
 
   <entry id="r_snw">
-    <type>real</type>  
-    <category>swrad</category> 
+    <type>real</type>
+    <category>swrad</category>
     <group>shortwave_nml</group>
     <desc>
       tuning parameter for delta-eddington shortwave for broadband snow albedo
@@ -1172,8 +1184,8 @@
   </entry>
 
   <entry id="dt_mlt">
-    <type>real</type>  
-    <category>swrad</category> 
+    <type>real</type>
+    <category>swrad</category>
     <group>shortwave_nml</group>
     <desc>
       melt onset temperature tunable parameter for dEdd albedo
@@ -1189,8 +1201,8 @@
   </entry>
 
   <entry id="rsnw_mlt">
-    <type>real</type>  
-    <category>swrad</category> 
+    <type>real</type>
+    <category>swrad</category>
     <group>shortwave_nml</group>
     <desc>
       maximum melting snow grain radius tunable parameter for dEdd albedo
@@ -1206,8 +1218,8 @@
   </entry>
 
   <entry id="kalg">
-    <type>real</type>  
-    <category>swrad</category> 
+    <type>real</type>
+    <category>swrad</category>
     <group>shortwave_nml</group>
     <desc>
       algae absorption coefficient for 0.5 m thick layer
@@ -1222,7 +1234,7 @@
   <!-- =========================== -->
 
   <entry id="hp1">
-    <type>real</type>  
+    <type>real</type>
     <category>parameterizations</category>
     <group>ponds_nml</group>
     <desc>
@@ -1234,7 +1246,7 @@
   </entry>
 
   <entry id="hs0">
-    <type>real</type>  
+    <type>real</type>
     <category>parameterizations</category>
     <group>ponds_nml</group>
     <desc>
@@ -1246,7 +1258,7 @@
   </entry>
 
   <entry id="hs1">
-    <type>real</type>  
+    <type>real</type>
     <category>parameterizations</category>
     <group>ponds_nml</group>
     <desc>
@@ -1258,11 +1270,11 @@
   </entry>
 
   <entry id="dpscale">
-    <type>real</type>  
+    <type>real</type>
     <category>parameterizations</category>
     <group>ponds_nml</group>
     <desc>
-      time scale for flushing in permeable ice 
+      time scale for flushing in permeable ice
     </desc>
     <values>
       <value> 1.0e-3 </value>
@@ -1270,7 +1282,7 @@
   </entry>
 
   <entry id="frzpnd">
-    <type>char</type>  
+    <type>char</type>
     <category>parameterizations</category>
     <group>ponds_nml</group>
     <desc>
@@ -1285,7 +1297,7 @@
   </entry>
 
   <entry id="rfracmin">
-    <type>real</type>  
+    <type>real</type>
     <category>parameterizations</category>
     <group>ponds_nml</group>
     <desc>
@@ -1299,7 +1311,7 @@
   </entry>
 
   <entry id="rfracmax">
-    <type>real</type>  
+    <type>real</type>
     <category>parameterizations</category>
     <group>ponds_nml</group>
     <desc>
@@ -1313,7 +1325,7 @@
   </entry>
 
   <entry id="pndaspect">
-    <type>real</type>  
+    <type>real</type>
     <category>parameterizations</category>
     <group>ponds_nml</group>
     <desc>

--- a/cime_config/testdefs/testmods_dirs/cice/default/user_nl_cice
+++ b/cime_config/testdefs/testmods_dirs/cice/default/user_nl_cice
@@ -4,6 +4,7 @@
 ! f_albsno	= 'dxxxx'
 ! f_albpnd	= 'dxxxx'
 !----------------------------------------------------------------------------------
+history_precision = 8
 histfreq	= 'd','x','x','x','x'
 histfreq_n	=  1,1,1,1,1
 f_bounds = .false.

--- a/cime_config/testdefs/testmods_dirs/cice/pop/user_nl_cice
+++ b/cime_config/testdefs/testmods_dirs/cice/pop/user_nl_cice
@@ -4,6 +4,7 @@
 ! f_albsno	= 'dxxxx'
 ! f_albpnd	= 'dxxxx'
 !----------------------------------------------------------------------------------
+history_precision = 8
 histfreq	= 'd','x','x','x','x'
 histfreq_n	=  1,1,1,1,1
 f_bounds = .false.

--- a/cime_config/testdefs/testmods_dirs/cice/step/user_nl_cice
+++ b/cime_config/testdefs/testmods_dirs/cice/step/user_nl_cice
@@ -4,6 +4,7 @@
 ! f_albsno	= '1xxxx'
 ! f_albpnd	= '1xxxx'
 !----------------------------------------------------------------------------------
+history_precision = 8
 histfreq	= '1','x','x','x','x'
 histfreq_n	=  1,1,1,1,1
 f_bounds = .false.

--- a/src/io_pio/ice_history_write.F90
+++ b/src/io_pio/ice_history_write.F90
@@ -19,11 +19,13 @@
       module ice_history_write
 
       use ice_kinds_mod
-
+      use pio, only : pio_real, pio_double
+      use ice_constants, only : spval, spval_dbl
       implicit none
       private
       public :: ice_write_hist
-      save
+
+      integer :: history_precision = pio_real
 
 !=======================================================================
 
@@ -43,7 +45,7 @@
       use ice_calendar, only: time, sec, idate, idate0, write_ic, &
           histfreq, histfreq_n, dayyr, days_per_year, use_leap_years
       use ice_communicate, only: my_task, master_task
-      use ice_constants, only: c0, c360, secday, spval, spval_dbl, rad_to_deg
+      use ice_constants, only: c0, c360, secday, rad_to_deg
       use ice_domain, only: distrb_info, nblocks
       use ice_domain_size, only: nx_global, ny_global, max_blocks, max_nstrm
       use ice_exit, only: abort_ice
@@ -61,13 +63,12 @@
       use pio
 
       integer (kind=int_kind), intent(in) :: ns
-
       ! local variables
 
 #ifdef ncdf
       integer (kind=int_kind) :: i,j,k,ic,n,nn, &
          ncid,status,imtid,jmtid,kmtidi,kmtids,kmtidb, cmtid,timid, &
-         length,nvertexid,ivertex
+         length,nvertexid,ivertex, iblk, ii
       integer (kind=int_kind), dimension(2) :: dimid2
       integer (kind=int_kind), dimension(3) :: dimid3
       integer (kind=int_kind), dimension(4) :: dimidz
@@ -124,6 +125,12 @@
       real (kind=dbl_kind), allocatable :: workr4(:,:,:,:,:)
       real (kind=dbl_kind), allocatable :: workr3v(:,:,:,:)
 
+      real (kind=real_kind), allocatable :: rworkr2(:,:,:)
+      real (kind=real_kind), allocatable :: rworkr3(:,:,:,:)
+      real (kind=real_kind), allocatable :: rworkr4(:,:,:,:,:)
+      real (kind=real_kind), allocatable :: rworkr3v(:,:,:,:)
+
+      real (kind=dbl_kind), pointer :: pworkr2(:,:,:), pworkr3(:,:,:,:)
       character(len=char_len_long) :: &
            filename
 
@@ -185,7 +192,7 @@
       ! define coordinate variables:  time, time_bounds
       !-----------------------------------------------------------------
 
-        status = pio_def_var(File,'time',pio_real,(/timid/),varid)
+        status = pio_def_var(File,'time',history_precision,(/timid/),varid)
         status = pio_put_att(File,varid,'long_name','model time')
 
         write(cdate,'(i8.8)') idate0
@@ -211,7 +218,7 @@
         if (hist_avg .and. histfreq(ns) /= '1') then
           dimid2(1) = boundid
           dimid2(2) = timid
-          status = pio_def_var(File,'time_bounds',pio_real,dimid2,varid)
+          status = pio_def_var(File,'time_bounds',history_precision,dimid2,varid)
           status = pio_put_att(File,varid,'long_name', &
                                 'boundaries for time-averaging interval')
           write(cdate,'(i8.8)') idate0
@@ -312,7 +319,7 @@
         dimid2(2) = jmtid
 
         do i = 1, ncoord
-          status = pio_def_var(File, trim(coord_var(i)%short_name), pio_real, &
+          status = pio_def_var(File, trim(coord_var(i)%short_name), history_precision, &
                                 dimid2, varid)
           status = pio_put_att(File,varid,'long_name',trim(coord_var(i)%long_name))
           status = pio_put_att(File, varid, 'units', trim(coord_var(i)%units))
@@ -335,7 +342,7 @@
 
 	do i = 1, nvarz
            if (igrdz(i)) then
-              status = pio_def_var(File, trim(var_nz(i)%short_name), pio_real, &
+              status = pio_def_var(File, trim(var_nz(i)%short_name), history_precision, &
                                    (/dimidex(i)/), varid)
               status = pio_put_att(File, varid, 'long_name', var_nz(i)%long_name)
               status = pio_put_att(File, varid, 'units'    , var_nz(i)%units)
@@ -344,7 +351,7 @@
 
         ! Attributes for tmask defined separately, since it has no units
         if (igrd(n_tmask)) then
-           status = pio_def_var(File, 'tmask', pio_real, dimid2, varid)
+           status = pio_def_var(File, 'tmask', history_precision, dimid2, varid)
            status = pio_put_att(File,varid, 'long_name', 'ocean grid mask')
            status = pio_put_att(File, varid, 'coordinates', 'TLON TLAT')
            status = pio_put_att(File, varid, 'missing_value', spval)
@@ -352,7 +359,7 @@
            status = pio_put_att(File,varid,'comment', '0 = land, 1 = ocean')
         endif
         if (igrd(n_blkmask)) then
-           status = pio_def_var(File, 'blkmask', pio_real, dimid2, varid)
+           status = pio_def_var(File, 'blkmask', history_precision, dimid2, varid)
            status = pio_put_att(File,varid, 'long_name', 'ice grid block mask')
            status = pio_put_att(File, varid, 'coordinates', 'TLON TLAT')
            status = pio_put_att(File,varid,'comment', 'mytask + iblk/100')
@@ -363,7 +370,7 @@
         do i = 3, nvar       ! note: n_tmask=1, n_blkmask=2
           if (igrd(i)) then
              status = pio_def_var(File, trim(var(i)%req%short_name), &
-                                   pio_real, dimid2, varid)
+                                   history_precision, dimid2, varid)
              status = pio_put_att(File,varid, 'long_name', trim(var(i)%req%long_name))
              status = pio_put_att(File, varid, 'units', trim(var(i)%req%units))
              status = pio_put_att(File, varid, 'coordinates', trim(var(i)%coordinates))
@@ -379,7 +386,7 @@
         do i = 1, nvar_verts
           if (f_bounds) then
              status = pio_def_var(File, trim(var_nverts(i)%short_name), &
-                                   pio_real,dimid_nverts, varid)
+                                   history_precision,dimid_nverts, varid)
              status = &
              pio_put_att(File,varid, 'long_name', trim(var_nverts(i)%long_name))
              status = &
@@ -404,7 +411,7 @@
         do n=1,num_avail_hist_fields_2D
           if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
             status  = pio_def_var(File, trim(avail_hist_fields(n)%vname), &
-                         pio_real, dimid3, varid)
+                         history_precision, dimid3, varid)
             status = pio_put_att(File,varid,'units', &
                         trim(avail_hist_fields(n)%vunit))
             status = pio_put_att(File,varid, 'long_name', &
@@ -452,7 +459,7 @@
         do n = n2D + 1, n3Dccum
           if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
             status  = pio_def_var(File, trim(avail_hist_fields(n)%vname), &
-                         pio_real, dimidz, varid)
+                         history_precision, dimidz, varid)
             status = pio_put_att(File,varid,'units', &
                         trim(avail_hist_fields(n)%vunit))
             status = pio_put_att(File,varid, 'long_name', &
@@ -489,7 +496,7 @@
         do n = n3Dccum + 1, n3Dzcum
           if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
             status  = pio_def_var(File, trim(avail_hist_fields(n)%vname), &
-                         pio_real, dimidz, varid)
+                         history_precision, dimidz, varid)
             status = pio_put_att(File,varid,'units', &
                         trim(avail_hist_fields(n)%vunit))
             status = pio_put_att(File,varid, 'long_name', &
@@ -526,7 +533,7 @@
         do n = n3Dzcum + 1, n3Dbcum
           if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
             status  = pio_def_var(File, trim(avail_hist_fields(n)%vname), &
-                         pio_real, dimidz, varid)
+                         history_precision, dimidz, varid)
             status = pio_put_att(File,varid,'units', &
                         trim(avail_hist_fields(n)%vunit))
             status = pio_put_att(File,varid, 'long_name', &
@@ -569,7 +576,7 @@
         do n = n3Dbcum + 1, n4Dicum
           if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
             status  = pio_def_var(File, trim(avail_hist_fields(n)%vname), &
-                             pio_real, dimidcz, varid)
+                             history_precision, dimidcz, varid)
             status = pio_put_att(File,varid,'units', &
                         trim(avail_hist_fields(n)%vunit))
             status = pio_put_att(File,varid, 'long_name', &
@@ -607,7 +614,7 @@
         do n = n4Dicum + 1, n4Dscum
           if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
             status  = pio_def_var(File, trim(avail_hist_fields(n)%vname), &
-                             pio_real, dimidcz, varid)
+                             history_precision, dimidcz, varid)
             status = pio_put_att(File,varid,'units', &
                         trim(avail_hist_fields(n)%vunit))
             status = pio_put_att(File,varid, 'long_name', &
@@ -645,7 +652,7 @@
         do n = n4Dscum + 1, n4Dbcum
           if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
             status  = pio_def_var(File, trim(avail_hist_fields(n)%vname), &
-                             pio_real, dimidcz, varid)
+                             history_precision, dimidcz, varid)
             status = pio_put_att(File,varid,'units', &
                         trim(avail_hist_fields(n)%vunit))
             status = pio_put_att(File,varid, 'long_name', &
@@ -763,24 +770,52 @@
       ! write coordinate variables
       !-----------------------------------------------------------------
 
-        allocate(workr2(nx_block,ny_block,nblocks))
-
+        if (history_precision == pio_real) then
+           allocate(rworkr2(nx_block,ny_block,nblocks))
+        else
+           allocate(workr2(nx_block,ny_block,nblocks))
+        endif
         do i = 1,ncoord
           status = pio_inq_varid(File, coord_var(i)%short_name, varid)
           SELECT CASE (coord_var(i)%short_name)
-            CASE ('TLON')
-              ! Convert T grid longitude from -180 -> 180 to 0 to 360
-                 workr2(:,:,:) = mod(tlon(:,:,1:nblocks)*rad_to_deg + c360, c360)
-            CASE ('TLAT')
-              workr2(:,:,:) = tlat(:,:,1:nblocks)*rad_to_deg
-            CASE ('ULON')
-              workr2(:,:,:) = ulon(:,:,1:nblocks)*rad_to_deg
-            CASE ('ULAT')
-              workr2(:,:,:) = ulat(:,:,1:nblocks)*rad_to_deg
+          CASE ('TLON')
+             pworkr2 => tlon
+          CASE ('TLAT')
+             pworkr2 => tlat
+          CASE ('ULON')
+             pworkr2 => ulon
+          CASE ('ULAT')
+             pworkr2 => ulat
           END SELECT
-          call pio_write_darray(File, varid, iodesc2d, &
-               workr2, status, fillval=spval_dbl)
-        enddo
+          if (history_precision == pio_real) then
+             ! Convert T grid longitude from -180 -> 180 to 0 to 360
+             rworkr2 = spval
+             do iblk=1,nblocks
+                do j=1,ny_block
+                   do ii=1,nx_block
+                      if (pworkr2(ii,j,iblk) .ne. spval_dbl) then
+                         if(coord_var(i)%short_name .eq. 'TLON') then
+                            rworkr2(ii,j,iblk) = real(mod(pworkr2(ii,j,iblk)*rad_to_deg + c360, c360), kind=real_kind)
+                         else
+                            rworkr2(ii,j,iblk) = real(pworkr2(ii,j,iblk)*rad_to_deg, kind=real_kind)
+                         endif
+                      endif
+                   enddo
+                enddo
+             enddo
+             call pio_write_darray(File, varid, iodesc2d, &
+                  rworkr2, status, fillval=spval)
+          else
+             if(coord_var(i)%short_name .eq. 'TLON') then
+                ! Convert T grid longitude from -180 -> 180 to 0 to 360
+                workr2(:,:,:) = mod(pworkr2(:,:,1:nblocks)*rad_to_deg + c360, c360)
+             else
+                workr2(:,:,:) = pworkr2(:,:,1:nblocks)*rad_to_deg
+                call pio_write_darray(File, varid, iodesc2d, &
+                     workr2, status, fillval=spval_dbl)
+             endif
+          endif
+       enddo
 
         ! Extra dimensions (NCAT, VGRD*)
 
@@ -819,33 +854,48 @@
          if (igrd(i)) then
             SELECT CASE (var(i)%req%short_name)
             CASE ('tmask')
-               workr2 = hm(:,:,1:nblocks)
+               pworkr2 => hm(:,:,1:nblocks)
             CASE ('blkmask')
-               workr2 = bm(:,:,1:nblocks)
+               pworkr2 => bm(:,:,1:nblocks)
             CASE ('tarea')
-               workr2 = tarea(:,:,1:nblocks)
+               pworkr2 => tarea(:,:,1:nblocks)
             CASE ('uarea')
-               workr2 = uarea(:,:,1:nblocks)
+               pworkr2 => uarea(:,:,1:nblocks)
             CASE ('dxu')
-               workr2 = dxu(:,:,1:nblocks)
+               pworkr2 => dxu(:,:,1:nblocks)
             CASE ('dyu')
-               workr2 = dyu(:,:,1:nblocks)
+               pworkr2 => dyu(:,:,1:nblocks)
             CASE ('dxt')
-               workr2 = dxt(:,:,1:nblocks)
+               pworkr2 => dxt(:,:,1:nblocks)
             CASE ('dyt')
-               workr2 = dyt(:,:,1:nblocks)
+               pworkr2 => dyt(:,:,1:nblocks)
             CASE ('HTN')
-               workr2 = HTN(:,:,1:nblocks)
+               pworkr2 => HTN(:,:,1:nblocks)
             CASE ('HTE')
-               workr2 = HTE(:,:,1:nblocks)
+               pworkr2 => HTE(:,:,1:nblocks)
             CASE ('ANGLE')
-               workr2 = ANGLE(:,:,1:nblocks)
+               pworkr2 => ANGLE(:,:,1:nblocks)
             CASE ('ANGLET')
-               workr2 = ANGLET(:,:,1:nblocks)
+               pworkr2 => ANGLET(:,:,1:nblocks)
             END SELECT
             status = pio_inq_varid(File, var(i)%req%short_name, varid)
-            call pio_write_darray(File, varid, iodesc2d, &
-                 workr2, status, fillval=spval_dbl)
+            if (history_precision == pio_real) then
+               rworkr2 = spval
+               do iblk=1,nblocks
+                  do j=1,ny_block
+                     do ii=1,nx_block
+                        if(pworkr2(ii,j,iblk) .ne. spval_dbl) then
+                           rworkr2(ii,j,iblk) = real(pworkr2(ii,j,iblk),kind=real_kind)
+                        endif
+                     enddo
+                  enddo
+               enddo
+               call pio_write_darray(File, varid, iodesc2d, &
+                    rworkr2, status, fillval=spval)
+            else
+               call pio_write_darray(File, varid, iodesc2d, &
+                    pworkr2, status, fillval=spval_dbl)
+            endif
          endif
       enddo
 
@@ -854,33 +904,90 @@
       !----------------------------------------------------------------
 
       if (f_bounds) then
-      allocate(workr3v(nverts,nx_block,ny_block,nblocks))
-      workr3v (:,:,:,:) = c0
-      do i = 1, nvar_verts
-        SELECT CASE (var_nverts(i)%short_name)
-        CASE ('lont_bounds')
-           do ivertex = 1, nverts
-              workr3v(ivertex,:,:,:) = lont_bounds(ivertex,:,:,1:nblocks)
-           enddo
-        CASE ('latt_bounds')
-           do ivertex = 1, nverts
-              workr3v(ivertex,:,:,:) = latt_bounds(ivertex,:,:,1:nblocks)
-           enddo
-        CASE ('lonu_bounds')
-           do ivertex = 1, nverts
-              workr3v(ivertex,:,:,:) = lonu_bounds(ivertex,:,:,1:nblocks)
-           enddo
-        CASE ('latu_bounds')
-           do ivertex = 1, nverts
-              workr3v(ivertex,:,:,:) = latu_bounds(ivertex,:,:,1:nblocks)
-           enddo
-        END SELECT
-
-          status = pio_inq_varid(File, var_nverts(i)%short_name, varid)
-          call pio_write_darray(File, varid, iodesc3dv, &
+         if (history_precision == pio_real) then
+            allocate(rworkr3v(nverts,nx_block,ny_block,nblocks))
+            rworkr3v (:,:,:,:) = spval
+         else
+            allocate(rworkr3v(nverts,nx_block,ny_block,nblocks))
+            workr3v (:,:,:,:) = spval_dbl
+         endif
+         do i = 1, nvar_verts
+            SELECT CASE (var_nverts(i)%short_name)
+            CASE ('lont_bounds')
+               if (history_precision == pio_real) then
+                  do iblk=1,nblocks
+                     do j=1,ny_block
+                        do ii=1,nx_block
+                           do ivertex = 1,nverts
+                              rworkr3v(ivertex, ii, j, iblk) = &
+                                   lont_bounds(ivertex, ii, j, iblk)
+                           enddo
+                        enddo
+                     enddo
+                  enddo
+               else
+                  workr3v(:,:,:,:) = lont_bounds(1:nverts,:,:,1:nblocks)
+               endif
+            CASE ('latt_bounds')
+               if (history_precision == pio_real) then
+                  do iblk=1,nblocks
+                     do j=1,ny_block
+                        do ii=1,nx_block
+                           do ivertex = 1,nverts
+                              rworkr3v(ivertex, ii, j, iblk) = &
+                                   latt_bounds(ivertex, ii, j, iblk)
+                           enddo
+                        enddo
+                     enddo
+                  enddo
+               else
+                  workr3v(:,:,:,:) = latt_bounds(1:nverts,:,:,1:nblocks)
+               endif
+            CASE ('lonu_bounds')
+               if (history_precision == pio_real) then
+                  do iblk=1,nblocks
+                     do j=1,ny_block
+                        do ii=1,nx_block
+                           do ivertex = 1,nverts
+                              rworkr3v(ivertex, ii, j, iblk) = &
+                                   lonu_bounds(ivertex, ii, j, iblk)
+                           enddo
+                        enddo
+                     enddo
+                  enddo
+               else
+                  workr3v(:,:,:,:) = lonu_bounds(1:nverts,:,:,1:nblocks)
+               endif
+            CASE ('latu_bounds')
+               if (history_precision == pio_real) then
+                  do iblk=1,nblocks
+                     do j=1,ny_block
+                        do ii=1,nx_block
+                           do ivertex = 1,nverts
+                              rworkr3v(ivertex, ii, j, iblk) = &
+                                   latu_bounds(ivertex, ii, j, iblk)
+                           enddo
+                        enddo
+                     enddo
+                  enddo
+               else
+                  workr3v(:,:,:,:) = latu_bounds(1:nverts,:,:,1:nblocks)
+               endif
+            END SELECT
+            status = pio_inq_varid(File, var_nverts(i)%short_name, varid)
+            if (history_precision == pio_real) then
+               call pio_write_darray(File, varid, iodesc3dv, &
+                                rworkr3v, status, fillval=spval)
+            else
+               call pio_write_darray(File, varid, iodesc3dv, &
                                 workr3v, status, fillval=spval_dbl)
+            endif
       enddo
-      deallocate(workr3v)
+      if (history_precision == pio_real) then
+         deallocate(rworkr3v)
+      else
+         deallocate(workr3v)
+      endif
       endif  ! f_bounds
 
 
@@ -894,76 +1001,161 @@
             status  = pio_inq_varid(File,avail_hist_fields(n)%vname,varid)
             if (status /= pio_noerr) call abort_ice( &
                'ice: Error getting varid for '//avail_hist_fields(n)%vname)
-            workr2(:,:,:) = a2D(:,:,n,1:nblocks)
             call pio_setframe(File, varid, int(1,kind=PIO_OFFSET_KIND))
-            call pio_write_darray(File, varid, iodesc2d,&
-                                  workr2, status, fillval=spval_dbl)
+            if (history_precision == pio_real) then
+               do iblk=1,nblocks
+                  do j=1,ny_block
+                     do ii=1,nx_block
+                        if (a2D(ii,j,n,iblk) .ne. spval_dbl) then
+                           rworkr2(ii,j,iblk) = real(a2d(ii,j,n,iblk),kind=real_kind)
+                        else
+                           rworkr2(ii,j,iblk) = spval
+                        endif
+                     enddo
+                  enddo
+               enddo
+               call pio_write_darray(File, varid, iodesc2d,&
+                    rworkr2, status, fillval=spval)
+            else
+               call pio_write_darray(File, varid, iodesc2d,&
+                    a2D(:,:,n,1:nblocks), status, fillval=spval_dbl)
+            endif
          endif
       enddo ! num_avail_hist_fields_2D
-
-      deallocate(workr2)
+      if (history_precision == pio_real) then
+         deallocate(rworkr2)
+      else
+         deallocate(workr2)
+      endif
 
       ! 3D (category)
-      allocate(workr3(nx_block,ny_block,nblocks,ncat_hist))
+      if (history_precision == pio_real) then
+         allocate(rworkr3(nx_block,ny_block,nblocks,ncat_hist))
+      else
+         allocate(workr3(nx_block,ny_block,nblocks,ncat_hist))
+      endif
       do n = n2D + 1, n3Dccum
          nn = n - n2D
          if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
             status  = pio_inq_varid(File,avail_hist_fields(n)%vname,varid)
             if (status /= pio_noerr) call abort_ice( &
                'ice: Error getting varid for '//avail_hist_fields(n)%vname)
-            do j = 1, nblocks
-            do i = 1, ncat_hist
-               workr3(:,:,j,i) = a3Dc(:,:,i,nn,j)
-            enddo
-            enddo
             call pio_setframe(File, varid, int(1,kind=PIO_OFFSET_KIND))
-            call pio_write_darray(File, varid, iodesc3dc,&
-                                  workr3, status, fillval=spval_dbl)
+            if (history_precision == pio_real) then
+               rworkr3 = spval
+               do iblk = 1, nblocks
+                  do i = 1, ncat_hist
+                     do j=1,ny_block
+                        do ii=1,nx_block
+                           if (a3Dc(ii,j,i,nn,iblk) .ne. spval_dbl) then
+                              rworkr3(ii,j,iblk,i) = real(a3Dc(ii,j,i,nn,iblk),kind=real_kind)
+                           endif
+                        enddo
+                     enddo
+                  enddo
+               enddo
+               call pio_write_darray(File, varid, iodesc3dc,&
+                    rworkr3, status, fillval=spval)
+            else
+               do iblk = 1, nblocks
+                  do i = 1, ncat_hist
+                     workr3(:,:,iblk,i) = a3Dc(:,:,i,nn,iblk)
+                  enddo
+               enddo
+               call pio_write_darray(File, varid, iodesc3dc,&
+                    workr3, status, fillval=spval_dbl)
+            endif
          endif
       enddo ! num_avail_hist_fields_3Dc
-      deallocate(workr3)
-
+      if (history_precision == pio_real) then
+         deallocate(rworkr3)
+         allocate(rworkr3(nx_block,ny_block,nblocks,nzilyr))
+      else
+         deallocate(workr3)
+         allocate(workr3(nx_block,ny_block,nblocks,nzilyr))
+      endif
       ! 3D (vertical ice)
-      allocate(workr3(nx_block,ny_block,nblocks,nzilyr))
       do n = n3Dccum+1, n3Dzcum
          nn = n - n3Dccum
          if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
             status  = pio_inq_varid(File,avail_hist_fields(n)%vname,varid)
             if (status /= pio_noerr) call abort_ice( &
                'ice: Error getting varid for '//avail_hist_fields(n)%vname)
-            do j = 1, nblocks
-            do i = 1, nzilyr
-               workr3(:,:,j,i) = a3Dz(:,:,i,nn,j)
-            enddo
-            enddo
             call pio_setframe(File, varid, int(1,kind=PIO_OFFSET_KIND))
-            call pio_write_darray(File, varid, iodesc3di,&
-                                  workr3, status, fillval=spval_dbl)
+            if (history_precision == pio_real) then
+               rworkr3 = spval
+               do i = 1, nzilyr
+                  do iblk = 1, nblocks
+                     do j=1,ny_block
+                        do ii=1,nx_block
+                           if(a3Dz(ii,j,i,nn,iblk).ne.spval_dbl) then
+                              rworkr3(:,:,iblk,i) = a3Dz(:,:,i,nn,iblk)
+                           endif
+                        enddo
+                     enddo
+                  enddo
+               enddo
+               call pio_write_darray(File, varid, iodesc3di,&
+                    rworkr3, status, fillval=spval)
+            else
+               do i = 1, nzilyr
+                  do iblk = 1, nblocks
+                     workr3(:,:,iblk,i) = a3Dz(:,:,i,nn,iblk)
+                  enddo
+               enddo
+               call pio_write_darray(File, varid, iodesc3di,&
+                    workr3, status, fillval=spval_dbl)
+            endif
          endif
       enddo ! num_avail_hist_fields_3Dz
-      deallocate(workr3)
-
+      if (history_precision == pio_real) then
+         deallocate(rworkr3)
+         allocate(rworkr3(nx_block,ny_block,nblocks,nzlyrb))
+      else
+         deallocate(workr3)
+         allocate(workr3(nx_block,ny_block,nblocks,nzlyrb))
+      endif
       ! 3D (vertical ice biology)
-      allocate(workr3(nx_block,ny_block,nblocks,nzlyrb))
       do n = n3Dzcum+1, n3Dbcum
          nn = n - n3Dzcum
          if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
             status  = pio_inq_varid(File,avail_hist_fields(n)%vname,varid)
             if (status /= pio_noerr) call abort_ice( &
                'ice: Error getting varid for '//avail_hist_fields(n)%vname)
-            do j = 1, nblocks
-            do i = 1, nzlyrb
-               workr3(:,:,j,i) = a3Db(:,:,i,nn,j)
-            enddo
-            enddo
             call pio_setframe(File, varid, int(1,kind=PIO_OFFSET_KIND))
-            call pio_write_darray(File, varid, iodesc3db,&
-                                  workr3, status, fillval=spval_dbl)
+            if (history_precision == pio_real) then
+               rworkr3 = spval
+               do iblk = 1, nblocks
+                  do i = 1, nzlyrb
+                     do j=1,ny_block
+                        do ii=1,nx_block
+                           if (a3Db(ii,j,i,nn,iblk) .ne. spval_dbl) then
+                              rworkr3(ii,j,iblk,i) = real(a3Db(ii,j,i,nn,iblk),kind=real_kind)
+                           endif
+                        enddo
+                     enddo
+                  enddo
+               enddo
+               call pio_write_darray(File, varid, iodesc3db,&
+                    rworkr3, status, fillval=spval)
+            else
+               do iblk = 1, nblocks
+                  do i = 1, nzlyrb
+                     workr3(:,:,iblk,i) = a3Db(:,:,i,nn,iblk)
+                  enddo
+               enddo
+               call pio_write_darray(File, varid, iodesc3db,&
+                    workr3, status, fillval=spval_dbl)
+            endif
          endif
       enddo ! num_avail_hist_fields_3Db
-      deallocate(workr3)
-
-      allocate(workr4(nx_block,ny_block,nblocks,ncat_hist,nzilyr))
+      if (history_precision == pio_real) then
+         deallocate(rworkr3)
+         allocate(rworkr4(nx_block,ny_block,nblocks,ncat_hist,nzilyr))
+      else
+         deallocate(workr3)
+         allocate(workr4(nx_block,ny_block,nblocks,ncat_hist,nzilyr))
+      endif
       ! 4D (categories, vertical ice)
       do n = n3Dbcum+1, n4Dicum
          nn = n - n3Dbcum
@@ -971,21 +1163,44 @@
             status  = pio_inq_varid(File,avail_hist_fields(n)%vname,varid)
             if (status /= pio_noerr) call abort_ice( &
                'ice: Error getting varid for '//avail_hist_fields(n)%vname)
-            do j = 1, nblocks
-            do i = 1, ncat_hist
-            do k = 1, nzilyr
-               workr4(:,:,j,i,k) = a4Di(:,:,k,i,nn,j)
-            enddo ! k
-            enddo ! i
-            enddo ! j
             call pio_setframe(File, varid, int(1,kind=PIO_OFFSET_KIND))
-            call pio_write_darray(File, varid, iodesc4di,&
-                                  workr4, status, fillval=spval_dbl)
+            if (history_precision == pio_real) then
+               rworkr4 = spval
+               do iblk = 1, nblocks
+                  do i = 1, ncat_hist
+                     do k = 1, nzilyr
+                        do j=1,ny_block
+                           do ii=1,nx_block
+                              if(a4Di(ii,j,k,i,nn,iblk) .ne. spval_dbl) then
+                                 rworkr4(ii,j,iblk,i,k) = a4Di(ii,j,k,i,nn,iblk)
+                              endif
+                           enddo ! ii
+                        enddo ! j
+                     enddo ! k
+                  enddo ! i
+               enddo ! iblk
+               call pio_write_darray(File, varid, iodesc4di,&
+                    rworkr4, status, fillval=spval)
+            else
+               do iblk = 1, nblocks
+                  do i = 1, ncat_hist
+                     do k = 1, nzilyr
+                        workr4(:,:,iblk,i,k) = a4Di(:,:,k,i,nn,iblk)
+                     enddo ! k
+                  enddo ! i
+               enddo ! iblk
+               call pio_write_darray(File, varid, iodesc4di,&
+                    workr4, status, fillval=spval_dbl)
+            endif
          endif
       enddo ! num_avail_hist_fields_4Di
-      deallocate(workr4)
-
-      allocate(workr4(nx_block,ny_block,nblocks,ncat_hist,nzslyr))
+      if (history_precision == pio_real) then
+         deallocate(rworkr4)
+         allocate(rworkr4(nx_block,ny_block,nblocks,ncat_hist,nzslyr))
+      else
+         deallocate(workr4)
+         allocate(workr4(nx_block,ny_block,nblocks,ncat_hist,nzslyr))
+      endif
       ! 4D (categories, vertical ice)
       do n = n4Dicum+1, n4Dscum
          nn = n - n4Dicum
@@ -993,20 +1208,44 @@
             status  = pio_inq_varid(File,avail_hist_fields(n)%vname,varid)
             if (status /= pio_noerr) call abort_ice( &
                'ice: Error getting varid for '//avail_hist_fields(n)%vname)
-            do j = 1, nblocks
-            do i = 1, ncat_hist
-            do k = 1, nzslyr
-               workr4(:,:,j,i,k) = a4Ds(:,:,k,i,nn,j)
-            enddo ! k
-            enddo ! i
-            enddo ! j
             call pio_setframe(File, varid, int(1,kind=PIO_OFFSET_KIND))
-            call pio_write_darray(File, varid, iodesc4ds,&
-                                  workr4, status, fillval=spval_dbl)
+
+            if (history_precision == pio_real) then
+               rworkr4 = spval
+               do iblk = 1, nblocks
+                  do i = 1, ncat_hist
+                     do k = 1, nzslyr
+                        do j=1,ny_block
+                           do ii=1,nx_block
+                              if( a4Ds(ii,j,k,i,nn,iblk) .ne. spval_dbl) then
+                                 rworkr4(ii,j,iblk,i,k) = &
+                                      real(a4Ds(ii,j,k,i,nn,iblk),kind=real_kind)
+                              endif
+                           enddo ! ii
+                        enddo ! j
+                     enddo ! k
+                  enddo ! i
+               enddo ! iblk
+               call pio_write_darray(File, varid, iodesc4ds,&
+                    rworkr4, status, fillval=spval)
+            else
+               do j = 1, nblocks
+                  do i = 1, ncat_hist
+                     do k = 1, nzslyr
+                        workr4(:,:,j,i,k) = a4Ds(:,:,k,i,nn,j)
+                     enddo ! k
+                  enddo ! i
+               enddo ! iblk
+               call pio_write_darray(File, varid, iodesc4ds,&
+                    workr4, status, fillval=spval_dbl)
+            endif
          endif
       enddo ! num_avail_hist_fields_4Ds
-      deallocate(workr4)
-
+      if (history_precision == pio_real) then
+         deallocate(rworkr4)
+      else
+         deallocate(workr4)
+      endif
 !     similarly for num_avail_hist_fields_4Db (define workr4b, iodesc4db)
 
 

--- a/src/io_pio/ice_pio.F90
+++ b/src/io_pio/ice_pio.F90
@@ -129,9 +129,10 @@
 
 !================================================================================
 
-   subroutine ice_pio_initdecomp_2d(iodesc)
+   subroutine ice_pio_initdecomp_2d(iodesc, ice_precision)
 
       type(io_desc_t), intent(out) :: iodesc
+      integer, intent(in), optional :: ice_precision
 
       integer (kind=int_kind) :: &
           iblk,ilo,ihi,jlo,jhi,lon,lat,i,j,n,k
@@ -139,6 +140,13 @@
       type(block) :: this_block
 
       integer(kind=pio_offset_kind), pointer :: dof2d(:)
+      integer :: lprecision
+
+      if (present(ice_precision)) then
+         lprecision = ice_precision
+      else
+         lprecision = pio_double
+      endif
 
       allocate(dof2d(nx_block*ny_block*nblocks))
 
@@ -166,7 +174,7 @@
          enddo !j
       end do
 
-      call pio_initdecomp(ice_pio_subsystem, pio_double, (/nx_global,ny_global/), &
+      call pio_initdecomp(ice_pio_subsystem, lprecision, (/nx_global,ny_global/), &
            dof2d, iodesc)
 
       deallocate(dof2d)
@@ -175,17 +183,25 @@
 
 !================================================================================
 
-   subroutine ice_pio_initdecomp_3d (ndim3, iodesc, remap)
+   subroutine ice_pio_initdecomp_3d (ndim3, iodesc, remap, ice_precision)
 
       integer(kind=int_kind), intent(in) :: ndim3
       type(io_desc_t), intent(out) :: iodesc
       logical, optional :: remap
+      integer, intent(in), optional :: ice_precision
       integer (kind=int_kind) :: &
           iblk,ilo,ihi,jlo,jhi,lon,lat,i,j,n,k
 
       type(block) :: this_block
       logical :: lremap
       integer(kind=pio_offset_kind), pointer :: dof3d(:)
+      integer :: lprecision
+
+      if(present(ice_precision)) then
+         lprecision = ice_precision
+      else
+         lprecision = pio_double
+      endif
 
       allocate(dof3d(nx_block*ny_block*nblocks*ndim3))
       lremap=.false.
@@ -243,7 +259,7 @@
          enddo !ndim3
       endif
 
-      call pio_initdecomp(ice_pio_subsystem, pio_double, (/nx_global,ny_global,ndim3/), &
+      call pio_initdecomp(ice_pio_subsystem, lprecision, (/nx_global,ny_global,ndim3/), &
            dof3d, iodesc)
 
       deallocate(dof3d)
@@ -252,19 +268,25 @@
 
 !================================================================================
 
-   subroutine ice_pio_initdecomp_3d_inner(ndim3, inner_dim, iodesc)
+   subroutine ice_pio_initdecomp_3d_inner(ndim3, inner_dim, iodesc, ice_precision)
 
       integer(kind=int_kind), intent(in) :: ndim3
       logical, intent(in) :: inner_dim
       type(io_desc_t), intent(out) :: iodesc
-
+      integer, intent(in), optional :: ice_precision
       integer (kind=int_kind) :: &
           iblk,ilo,ihi,jlo,jhi,lon,lat,i,j,n,k
 
       type(block) :: this_block
 
       integer(kind=pio_offset_kind), pointer :: dof3d(:)
+      integer :: lprecision
 
+      if(present(ice_precision)) then
+         lprecision = ice_precision
+      else
+         lprecision = pio_double
+      endif
       allocate(dof3d(nx_block*ny_block*nblocks*ndim3))
 
       n=0
@@ -293,25 +315,31 @@
          enddo  !j
       end do    !iblk
 
-      call pio_initdecomp(ice_pio_subsystem, pio_double, (/ndim3,nx_global,ny_global/), &
+      call pio_initdecomp(ice_pio_subsystem, lprecision, (/ndim3,nx_global,ny_global/), &
            dof3d, iodesc)
 
       deallocate(dof3d)
 
    end subroutine ice_pio_initdecomp_3d_inner
 
-   subroutine ice_pio_initdecomp_4d (ndim3, ndim4, iodesc)
+   subroutine ice_pio_initdecomp_4d (ndim3, ndim4, iodesc, ice_precision)
 
       integer(kind=int_kind), intent(in) :: ndim3, ndim4
       type(io_desc_t), intent(out) :: iodesc
-
+      integer, intent(in), optional :: ice_precision
       integer (kind=int_kind) :: &
           iblk,ilo,ihi,jlo,jhi,lon,lat,i,j,n,k,l
 
       type(block) :: this_block
 
       integer(kind=pio_offset_kind), pointer :: dof4d(:)
+      integer :: lprecision
 
+      if(present(ice_precision)) then
+         lprecision = ice_precision
+      else
+         lprecision = pio_double
+      endif
       allocate(dof4d(nx_block*ny_block*nblocks*ndim3*ndim4))
 
       n=0
@@ -344,7 +372,7 @@
       enddo !ndim3
       enddo !ndim4
 
-      call pio_initdecomp(ice_pio_subsystem, pio_double, &
+      call pio_initdecomp(ice_pio_subsystem, lprecision, &
           (/nx_global,ny_global,ndim3,ndim4/), dof4d, iodesc)
 
       deallocate(dof4d)

--- a/src/source/ice_history_shared.F90
+++ b/src/source/ice_history_shared.F90
@@ -3,17 +3,17 @@
 !
 ! Output files: netCDF or binary data, Fortran unformatted dumps
 !
-! The following variables are currently hard-wired as snapshots 
+! The following variables are currently hard-wired as snapshots
 !   (instantaneous rather than time-averages):
 !   divu, shear, sig1, sig2, trsig, mlt_onset, frz_onset, hisnap, aisnap
 !
 ! Options for histfreq: '1','h','d','m','y','x', where x means that
-!   output stream will not be used (recommended for efficiency).  
-! histfreq_n can be any nonnegative integer, where 0 means that the 
+!   output stream will not be used (recommended for efficiency).
+! histfreq_n can be any nonnegative integer, where 0 means that the
 !   corresponding histfreq frequency will not be used.
 ! The flags (f_<field>) can be set to '1','h','d','m','y' or 'x', where
 !   n means the field will not be written.  To output the same field at
-!   more than one frequency, for instance monthy and daily, set 
+!   more than one frequency, for instance monthy and daily, set
 !   f_<field> = 'md'.
 !
 ! authors Tony Craig and Bruce Briegleb, NCAR
@@ -32,7 +32,7 @@
 
       private
       public :: define_hist_field, accum_hist_field, icefields_nml, construct_filename
-      
+
       logical (kind=log_kind), public :: &
          hist_avg  ! if true, write averaged data instead of snapshots
 
@@ -125,7 +125,7 @@
          a4Di(:,:,:,:,:,:), & ! field accumulations/averages, 4D categories,vertical, ice
          a4Ds(:,:,:,:,:,:), & ! field accumulations/averages, 4D categories,vertical, snow
          a4Db(:,:,:,:,:,:)    ! field accumulations/averages, 4D categories,vertical, bio
-         
+
       real (kind=dbl_kind), allocatable, public :: &
          Tinz4d (:,:,:,:)    , & ! array for Tin
          Tsnz4d (:,:,:,:)    , & ! array for Tsn
@@ -133,6 +133,8 @@
 
       real (kind=dbl_kind), public :: &
          avgct(max_nstrm)   ! average sample counter
+
+      integer (kind=int_kind), public :: history_precision
 
       logical (kind=log_kind), public :: &
          igrd (nvar), &        ! true if grid field is written to output file
@@ -158,12 +160,12 @@
          tstr4Db = 'TLON TLAT VGRDb NCAT', & ! vcoord for T cell, 4D, bio
          ustr4Db = 'ULON ULAT VGRDb NCAT'    ! vcoord for U cell, 4D, bio
 !ferret
-!         tstr4Di  = 'TLON TLAT VGRDi NCAT time', & ! ferret can not handle time 
+!         tstr4Di  = 'TLON TLAT VGRDi NCAT time', & ! ferret can not handle time
 !         ustr4Di  = 'ULON ULAT VGRDi NCAT time', & ! index on 4D variables.
 !         tstr4Ds  = 'TLON TLAT VGRDs NCAT time', & ! Use 'ferret' lines instead
 !         ustr4Ds  = 'ULON ULAT VGRDs NCAT time', & ! (below also)
-!         tstr4Db  = 'TLON TLAT VGRDb NCAT time', & 
-!         ustr4Db  = 'ULON ULAT VGRDb NCAT time'    
+!         tstr4Db  = 'TLON TLAT VGRDb NCAT time', &
+!         ustr4Db  = 'ULON ULAT VGRDb NCAT time'
 
       !---------------------------------------------------------------
       ! flags: write to output file if true or histfreq value
@@ -298,13 +300,13 @@
            f_keffn_top = 'x', &
            f_Tinz      = 'x', f_Sinz       = 'x', &
            f_Tsnz      = 'x', &
-           f_a11       = 'x', f_a12        = 'x', & 
-           f_e11       = 'x', f_e12        = 'x', & 
-           f_e22       = 'x',			  & 
-           f_s11       = 'x', f_s12        = 'x', & 
-           f_s22       = 'x',		          & 
-           f_yieldstress11       = 'x', 	  & 
-           f_yieldstress12       = 'x',           & 
+           f_a11       = 'x', f_a12        = 'x', &
+           f_e11       = 'x', f_e12        = 'x', &
+           f_e22       = 'x',			  &
+           f_s11       = 'x', f_s12        = 'x', &
+           f_s22       = 'x',		          &
+           f_yieldstress11       = 'x', 	  &
+           f_yieldstress12       = 'x',           &
            f_yieldstress22       = 'x'
 
       !---------------------------------------------------------------
@@ -329,7 +331,7 @@
            f_uatm,      f_vatm     , &
            f_fswdn,     f_flwdn    , &
            f_fswup, &
-           f_snow,      f_snow_ai  , &     
+           f_snow,      f_snow_ai  , &
            f_rain,      f_rain_ai  , &
            f_sst,       f_sss      , &
            f_uocn,      f_vocn     , &
@@ -353,8 +355,8 @@
            f_snoice,    f_dsnow    , &
            f_meltt,     f_melts    , &
            f_meltb,     f_meltl    , &
-           f_fresh,     f_fresh_ai , &  
-           f_fsalt,     f_fsalt_ai , &  
+           f_fresh,     f_fresh_ai , &
+           f_fsalt,     f_fsalt_ai , &
            f_fhocn,     f_fhocn_ai , &
            f_fswthru,   f_fswthru_ai,&
            f_strairx,   f_strairy  , &
@@ -443,7 +445,7 @@
            f_e22                   , &
            f_s11, 	f_s12	   , &
            f_s22                   , &
-           f_yieldstress11         , &	
+           f_yieldstress11         , &
            f_yieldstress12	   , &
            f_yieldstress22
 
@@ -458,7 +460,7 @@
            n_uarea      = 4,  &
            n_dxt        = 5,  &
            n_dyt        = 6,  &
-           n_dxu        = 7,  & 
+           n_dxu        = 7,  &
            n_dyu        = 8,  &
            n_HTN        = 9,  &
            n_HTE        = 10, &
@@ -584,7 +586,7 @@
            n_trsig      , n_icepresent , &
            n_iage       , n_FY         , &
            n_fsurf_ai   , &
-           n_fcondtop_ai, n_fmeltt_ai  , &   
+           n_fcondtop_ai, n_fmeltt_ai  , &
            n_aicen      , n_vicen      , &
            n_fsurfn_ai   , &
            n_fcondtopn_ai, &
@@ -730,7 +732,7 @@
 
       character (len=*), intent(in) :: &
          vhistfreq      ! history frequency
- 
+
       integer (kind=int_kind), intent(in) :: &
          ns             ! history file stream index
 
@@ -821,7 +823,7 @@
       integer (int_kind), dimension(max_nstrm), intent(in) :: &
          id                ! location in avail_fields array for use in
                            ! later routines
-        
+
       integer (kind=int_kind), intent(in) :: iblk
 
       real (kind=dbl_kind), intent(in) :: &
@@ -880,7 +882,7 @@
       integer (int_kind), dimension(max_nstrm), intent(in) :: &
          id                ! location in avail_fields array for use in
                            ! later routines
-        
+
       integer (kind=int_kind), intent(in) :: iblk
 
       integer (kind=int_kind), intent(in) :: &
@@ -944,7 +946,7 @@
       integer (int_kind), dimension(max_nstrm), intent(in) :: &
          id                ! location in avail_fields array for use in
                            ! later routines
-        
+
       integer (kind=int_kind), intent(in) :: iblk
 
       integer (kind=int_kind), intent(in) :: &

--- a/src/source/ice_init.F90
+++ b/src/source/ice_init.F90
@@ -645,6 +645,22 @@
          endif
       endif
 
+         if (.not. tr_lvl) then
+         if (my_task == master_task) then
+            write (nu_diag,*) 'WARNING: formdrag=T but tr_lvl=F'
+            write (nu_diag,*) 'WARNING: Setting tr_lvl=T'
+         endif
+         tr_lvl = .true.
+      endif
+   endif
+
+      if (trim(fbot_xfer_type) == 'Cdn_ocn' .and. .not. formdrag)  then
+         if (my_task == master_task) then
+            write (nu_diag,*) 'WARNING: formdrag=F but fbot_xfer_type=Cdn_ocn'
+            write (nu_diag,*) 'WARNING: Setting fbot_xfer_type = constant'
+         endif
+         fbot_xfer_type = 'constant'
+      endif
       if (my_task == master_task) then
          if(history_precision .ne. 4 .and. history_precision .ne. 8) then
             write (nu_diag,*) 'ERROR: bad value for history_precision, allowed values: 4, 8'
@@ -657,22 +673,6 @@
          endif
       endif
 
-      if (.not. tr_lvl) then
-         if (my_task == master_task) then
-            write (nu_diag,*) 'WARNING: formdrag=T but tr_lvl=F'
-            write (nu_diag,*) 'WARNING: Setting tr_lvl=T'
-         endif
-         tr_lvl = .true.
-      endif
-      endif
-
-      if (trim(fbot_xfer_type) == 'Cdn_ocn' .and. .not. formdrag)  then
-         if (my_task == master_task) then
-            write (nu_diag,*) 'WARNING: formdrag=F but fbot_xfer_type=Cdn_ocn'
-            write (nu_diag,*) 'WARNING: Setting fbot_xfer_type = constant'
-         endif
-         fbot_xfer_type = 'constant'
-      endif
 
 
       call broadcast_scalar(history_precision,      master_task)

--- a/src/source/ice_init.F90
+++ b/src/source/ice_init.F90
@@ -6,7 +6,7 @@
 ! authors Elizabeth C. Hunke and William H. Lipscomb, LANL
 !         C. M. Bitz, UW
 !
-! 2004 WHL: Block structure added 
+! 2004 WHL: Block structure added
 ! 2006 ECH: Added namelist variables, warnings.
 !           Replaced old default initial ice conditions with 3.14 version.
 !           Converted to free source form (F90).
@@ -53,7 +53,7 @@
           restart, restart_ext, restart_dir, restart_file, pointer_file, &
           runid, runtype, use_restart_time, restart_format, lcdf64
       use ice_history_shared, only: hist_avg, history_dir, history_file, &
-                             incond_dir, incond_file
+                             incond_dir, incond_file, history_precision
       use ice_exit, only: abort_ice
       use ice_itd, only: kitd, kcatbound
       use ice_ocean, only: oceanmixed_ice, tfrz_option
@@ -91,6 +91,7 @@
                                  dSdt_slow_mode, phi_c_slow_mode, &
                                  phi_i_mushy
       use ice_restoring, only: restore_ice
+      use pio, only : pio_real, pio_double
 #ifdef CESMCOUPLED
       use shr_file_mod, only: shr_file_setIO
 #endif
@@ -106,7 +107,7 @@
 
       logical :: exists
 
-      real (kind=real_kind) :: rpcesm, rplvl, rptopo 
+      real (kind=real_kind) :: rpcesm, rplvl, rptopo
 
       !-----------------------------------------------------------------
       ! Namelist variables.
@@ -123,7 +124,7 @@
         print_global,   print_points,   latpnt,          lonpnt,        &
         dbug,           histfreq,       histfreq_n,      hist_avg,      &
         history_dir,    history_file,                                   &
-        write_ic,       incond_dir,     incond_file
+        write_ic,       incond_dir,     incond_file, history_precision
 
       namelist /grid_nml/ &
         grid_format,    grid_type,       grid_file,     kmt_file,       &
@@ -181,9 +182,9 @@
       istep0 = 0             ! no. of steps taken in previous integrations,
                              ! real (dumped) or imagined (to set calendar)
 #ifndef CESMCOUPLED
-      dt = 3600.0_dbl_kind   ! time step, s      
+      dt = 3600.0_dbl_kind   ! time step, s
 #endif
-      npt = 99999            ! total number of time steps (dt) 
+      npt = 99999            ! total number of time steps (dt)
       diagfreq = 24          ! how often diag output is written
       print_points = .false. ! if true, print point data
       print_global = .true.  ! if true, print global diagnostic data
@@ -195,7 +196,7 @@
       histfreq(3) = 'd'      ! output frequency option for different streams
       histfreq(4) = 'm'      ! output frequency option for different streams
       histfreq(5) = 'y'      ! output frequency option for different streams
-      histfreq_n(:) = 1      ! output frequency 
+      histfreq_n(:) = 1      ! output frequency
       hist_avg = .true.      ! if true, write time-averages (not snapshots)
       history_dir  = './'    ! write to executable dir for default
       history_file = 'iceh'  ! history file name prefix
@@ -213,6 +214,7 @@
       pointer_file = 'ice.restart_file'
       restart_format = 'nc'  ! file format ('bin'=binary or 'nc'=netcdf or 'pio')
       lcdf64       = .false. ! 64 bit offset for netCDF
+      history_precision = 4    ! write history files in single precision
       ice_ic       = 'default'      ! latitude and sst-dependent
       grid_format  = 'bin'          ! file format ('bin'=binary or 'nc'=netcdf)
       grid_type    = 'rectangular'  ! define rectangular grid internally
@@ -231,7 +233,7 @@
       krdg_partic = 1        ! 1 = new participation, 0 = Thorndike et al 75
       krdg_redist = 1        ! 1 = new redistribution, 0 = Hibler 80
       mu_rdg = 3             ! e-folding scale of ridged ice, krdg_partic=1 (m^0.5)
-      Cf = 17.0_dbl_kind     ! ratio of ridging work to PE change in ridging 
+      Cf = 17.0_dbl_kind     ! ratio of ridging work to PE change in ridging
       advection  = 'remap'   ! incremental remapping transport scheme
       shortwave = 'default'  ! 'default' or 'dEdd' (delta-Eddington)
       albedo_type = 'default'! or 'constant'
@@ -254,7 +256,7 @@
       hp1       = 0.01_dbl_kind   ! critical pond lid thickness for topo ponds
       hs0       = 0.03_dbl_kind   ! snow depth for transition to bare sea ice (m)
       hs1       = 0.03_dbl_kind   ! snow depth for transition to bare pond ice (m)
-      dpscale   = c1              ! alter e-folding time scale for flushing 
+      dpscale   = c1              ! alter e-folding time scale for flushing
       frzpnd    = 'cesm'          ! melt pond refreezing parameterization
       rfracmin  = 0.15_dbl_kind   ! minimum retained fraction of meltwater
       rfracmax  = 0.85_dbl_kind   ! maximum retained fraction of meltwater
@@ -304,7 +306,7 @@
       restart_age  = .false. ! ice age restart
       tr_FY        = .false. ! ice age
       restart_FY   = .false. ! ice age restart
-      tr_lvl       = .false. ! level ice 
+      tr_lvl       = .false. ! level ice
       restart_lvl  = .false. ! level ice restart
       tr_pond_cesm = .false. ! CESM melt ponds
       restart_pond_cesm = .false. ! melt ponds restart
@@ -341,7 +343,7 @@
             nml_error = -1
          else
             nml_error =  1
-         endif 
+         endif
 
          do while (nml_error > 0)
             print*,'Reading setup_nml'
@@ -442,7 +444,7 @@
             'WARNING: runtype, restart, ice_ic are inconsistent:'
             write(nu_diag,*) trim(runtype), restart, trim(ice_ic)
             write(nu_diag,*) &
-            'WARNING: Initializing with NO ICE: ' 
+            'WARNING: Initializing with NO ICE: '
             write(nu_diag,*) ' '
             endif
             ice_ic = 'none'
@@ -463,7 +465,7 @@
       ! netcdf is unavailable
       grid_format     = 'bin'
       atm_data_format = 'bin'
-      ocn_data_format = 'bin' 
+      ocn_data_format = 'bin'
 #endif
 
       chartmp = advection(1:6)
@@ -609,7 +611,7 @@
       endif
 #endif
 
-      if (trim(atm_data_type) == 'hadgem' .and. & 
+      if (trim(atm_data_type) == 'hadgem' .and. &
              trim(precip_units) /= 'mks') then
          if (my_task == master_task) &
          write (nu_diag,*) &
@@ -638,8 +640,20 @@
 
       if (tr_pond_cesm) then
          if (my_task == master_task) then
-            write (nu_diag,*) 'ERROR: formdrag=T but frzpnd=''cesm''' 
+            write (nu_diag,*) 'ERROR: formdrag=T but frzpnd=''cesm'''
             call abort_ice('ice_init: Formdrag and no hlid')
+         endif
+      endif
+
+      if (my_task == master_task) then
+         if(history_precision .ne. 4 .and. history_precision .ne. 8) then
+            write (nu_diag,*) 'ERROR: bad value for history_precision, allowed values: 4, 8'
+            call abort_ice('ice_init: history_precision')
+         endif
+         if( history_precision == 4) then
+            history_precision = pio_real
+         else
+            history_precision = pio_double
          endif
       endif
 
@@ -661,6 +675,7 @@
       endif
 
 
+      call broadcast_scalar(history_precision,      master_task)
       call broadcast_scalar(days_per_year,      master_task)
       call broadcast_scalar(use_leap_years,     master_task)
       call broadcast_scalar(year_init,          master_task)
@@ -675,7 +690,7 @@
       call broadcast_scalar(diag_file,          master_task)
       do n = 1, max_nstrm
          call broadcast_scalar(histfreq(n),     master_task)
-      enddo  
+      enddo
       call broadcast_array(histfreq_n,          master_task)
       call broadcast_scalar(hist_avg,           master_task)
       call broadcast_scalar(history_dir,        master_task)
@@ -833,6 +848,13 @@
          write(nu_diag,1050) ' histfreq                  = ', histfreq(:)
          write(nu_diag,1040) ' histfreq_n                = ', histfreq_n(:)
          write(nu_diag,1010) ' hist_avg                  = ', hist_avg
+         if(history_precision == pio_real) then
+            write(nu_diag,*) ' history_precision     = 4'
+         elseif(history_precision == pio_double) then
+            write(nu_diag,*) ' history_precision     = 8'
+         else
+            write(nu_diag,1020) ' history_precision     = ',history_precision
+         endif
          if (.not. hist_avg) write (nu_diag,*) 'History data will be snapshots'
          write(nu_diag,*)    ' history_dir               = ', &
                                trim(history_dir)
@@ -956,7 +978,7 @@
                                trim(atm_data_dir)
             write(nu_diag,*) ' precip_units              = ', &
                                trim(precip_units)
-         endif 
+         endif
 
          write(nu_diag,1010) ' update_ocn_f              = ', update_ocn_f
          write(nu_diag,1010) ' l_mpond_fresh             = ', l_mpond_fresh
@@ -982,12 +1004,12 @@
                                trim(ocn_data_dir)
             write(nu_diag,1010) ' restore_sst               = ', &
                                restore_sst
-         endif 
+         endif
          write(nu_diag,1010) ' restore_ice               = ', &
                                restore_ice
          if (restore_ice .or. restore_sst) &
          write(nu_diag,1020) ' trestore                  = ', trestore
- 
+
 #ifdef CESMCOUPLED
 #define coupled
 #endif
@@ -1073,7 +1095,7 @@
                  nt_ipnd = ntrcr      ! on level-ice ponds (if frzpnd='hlid')
              endif
              if (tr_pond_topo) then
-                 ntrcr = ntrcr + 1    ! 
+                 ntrcr = ntrcr + 1    !
                  nt_ipnd = ntrcr      ! refrozen pond ice lid thickness
              endif
          endif
@@ -1083,18 +1105,18 @@
              nt_aero = ntrcr + 1
              ntrcr = ntrcr + 4*n_aero ! 4 dEdd layers, n_aero species
          endif
-              
+
          nt_iso = 0
          if (tr_iso) then
              nt_iso = ntrcr + 1
              ntrcr = ntrcr + 4*n_iso ! 4 dEdd layers, n_iso species
          endif
-              
+
          if (ntrcr > max_ntrcr) then
             write(nu_diag,*) 'max_ntrcr < number of namelist tracers'
             write(nu_diag,*) 'max_ntrcr = ',max_ntrcr,' ntrcr = ',ntrcr
             call abort_ice('max_ntrcr < number of namelist tracers')
-         endif                               
+         endif
 
          write(nu_diag,*) ' '
          write(nu_diag,1020) 'ntrcr = ', ntrcr
@@ -1122,7 +1144,7 @@
              grid_type  /=  'rectangular'    .and. &
              grid_type  /=  'cpom_grid'      .and. &
              grid_type  /=  'regional'       .and. &
-             grid_type  /=  'latlon' ) then 
+             grid_type  /=  'latlon' ) then
             call abort_ice('ice_init: unknown grid_type')
          endif
 
@@ -1207,7 +1229,7 @@
       !-----------------------------------------------------------------
 
       if (my_task == master_task) then
- 
+
          if (nilyr < 1) then
             write (nu_diag,*) 'nilyr =', nilyr
             write (nu_diag,*) 'Must have at least one ice layer'
@@ -1297,7 +1319,7 @@
       !$OMP                     iglob,jglob)
       do iblk = 1, nblocks
 
-         this_block = get_block(blocks_ice(iblk),iblk)         
+         this_block = get_block(blocks_ice(iblk),iblk)
          ilo = this_block%ilo
          ihi = this_block%ihi
          jlo = this_block%jlo
@@ -1400,7 +1422,7 @@
          iglob(nx_block)   , & ! global indices
          jglob(ny_block)       !
 
-      character(len=char_len_long), intent(in) :: & 
+      character(len=char_len_long), intent(in) :: &
          ice_ic      ! method of ice cover initialization
 
       logical (kind=log_kind), dimension (nx_block,ny_block), &
@@ -1414,8 +1436,8 @@
 
       real (kind=dbl_kind), dimension (nx_block,ny_block), intent(in) :: &
          Tair    , & ! air temperature  (K)
-         Tf      , & ! freezing temperature (C) 
-         sst         ! sea surface temperature (C) 
+         Tf      , & ! freezing temperature (C)
+         sst         ! sea surface temperature (C)
 
       real (kind=dbl_kind), dimension (nx_block,ny_block,nilyr), &
          intent(in) :: &
@@ -1453,7 +1475,7 @@
 
       real (kind=dbl_kind), parameter :: &
          hsno_init = 0.20_dbl_kind   , & ! initial snow thickness (m)
-         edge_init_nh =  70._dbl_kind, & ! initial ice edge, N.Hem. (deg) 
+         edge_init_nh =  70._dbl_kind, & ! initial ice edge, N.Hem. (deg)
          edge_init_sh = -60._dbl_kind    ! initial ice edge, S.Hem. (deg)
 
       indxi(:) = 0
@@ -1468,7 +1490,7 @@
             aicen(i,j,n) = c0
             vicen(i,j,n) = c0
             vsnon(i,j,n) = c0
-            trcrn(i,j,nt_Tsfc,n) = Tf(i,j)  ! surface temperature 
+            trcrn(i,j,nt_Tsfc,n) = Tf(i,j)  ! surface temperature
             if (max_ntrcr >= 2) then
                do it = 2, max_ntrcr
                   trcrn(i,j,it,n) = c0
@@ -1512,9 +1534,9 @@
 
       ! initial category areas in cells with ice
          hbar = c3  ! initial ice thickness with greatest area
-                    ! Note: the resulting average ice thickness 
+                    ! Note: the resulting average ice thickness
                     ! tends to be less than hbar due to the
-                    ! nonlinear distribution of ice thicknesses 
+                    ! nonlinear distribution of ice thicknesses
          sum = c0
          do n = 1, ncat
             if (n < ncat) then
@@ -1613,7 +1635,7 @@
 
             ! surface temperature
             if (calc_Tsfc) then
-        
+
                do ij = 1, icells
                   i = indxi(ij)
                   j = indxj(ij)
@@ -1634,7 +1656,7 @@
 
             if (heat_capacity) then
 
-               ! ice enthalpy, salinity 
+               ! ice enthalpy, salinity
                do k = 1, nilyr
                   do ij = 1, icells
                      i = indxi(ij)
@@ -1668,7 +1690,7 @@
                      j = indxj(ij)
                      Ti = min(c0, trcrn(i,j,nt_Tsfc,n))
                      trcrn(i,j,nt_qsno+k-1,n) = -rhos*(Lfresh - cp_ice*Ti)
-                     
+
                   enddo            ! ij
                enddo               ! nslyr
 
@@ -1680,7 +1702,7 @@
                do ij = 1, icells
                   i = indxi(ij)
                   j = indxj(ij)
-                  trcrn(i,j,nt_qice+k-1,n) = -rhoi * Lfresh 
+                  trcrn(i,j,nt_qice+k-1,n) = -rhoi * Lfresh
                   trcrn(i,j,nt_sice+k-1,n) = salinz(i,j,k)
                enddo            ! ij
 
@@ -1688,7 +1710,7 @@
                do ij = 1, icells
                   i = indxi(ij)
                   j = indxj(ij)
-                  trcrn(i,j,nt_qsno+k-1,n) = -rhos * Lfresh 
+                  trcrn(i,j,nt_qsno+k-1,n) = -rhos * Lfresh
                enddo            ! ij
 
             endif               ! heat_capacity


### PR DESCRIPTION
Provides support for double precision IO in the cice history file.   Default is single precision,
but double precision is set for all testing.   Tested with single and double precision using 
ERI.f09_g17.DTEST.cheyenne_intel.cice-default
and PET_Ln3.f45_g37.DTEST.cheyenne_intel.cice-step
and both PIO_VERSION=1 and PIO_VERSION=2
This also fixes the issue of fill pattern differences between otherwise identical run and thus the issue of INFO_DBUG giving different results with different pe layouts.