### PR TITLE
Support a %CMIP6 compset modifier

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -5,8 +5,9 @@
 <entry_id version="3.0">
 
   <description>
-    <desc ice="CICE[%PRES]">Sea ICE (cice) model version 5</desc>
-    <desc option="PRES"> :prescribed cice</desc>
+    <desc ice="CICE[%PRES][%CMIP6]">Sea ICE (cice) model version 5</desc>
+    <desc option="PRES" > :prescribed cice</desc>
+    <desc option="CMIP6"> :with modifications appropriate for CMIP6 experiments</desc>
   </description>
 
   <entry id="COMP_ICE">
@@ -149,6 +150,18 @@
     </desc>
   </entry>
 
+  <entry id="CICE_USER_MODS">
+    <type>char</type>
+    <valid_values></valid_values>
+    <default_value></default_value>
+    <values match="last">
+      <value
+      compset="_CICE[^_]*%CMIP6">$SRCROOT/components/cice/cime_config/usermods_dirs/cmip6</value>
+    </values>
+    <group>run_component_cice</group>
+    <file>env_case.xml</file>
+    <desc>User mods to apply to specific compset matches. </desc>
+  </entry>
 
   <help>
     =========================================

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -24,8 +24,7 @@
     <valid_values>prognostic,prescribed,thermo_only</valid_values>
     <default_value>prognostic</default_value>
     <values>
-      <value compset="CICE_">prognostic</value>
-      <value compset="CICE%PRES_">prescribed</value>
+      <value compset="_CICE[^_]*%PRES">prescribed</value>
     </values>
     <group>build_component_cice</group>
     <file>env_build.xml</file>


### PR DESCRIPTION
This allows us to have a compset like B1850cmip6, whose long name is:
1850_CAM60_CLM50%BGC-CROP-CMIP6DECK_CICE%CMIP6_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD
which turns on cmip6-specific usermods for CICE and CLM (and later CAM).

I'm not tied to the specific name of this modifier, `%CMIP6`. In particular, if you foresee a possible need to have different settings for different settings of CMIP6 experiments, you may want to change this to something like `%CMIP6DECK`, or whatever else is appropriate: Using simply `%CMIP6` will make regular expression matches messy down the line if additional options are needed (for example, it's harder to write a regex that matches a `%CMIP6` modifier but not a `%CMIP6FOO` modifier).