### PR TITLE
pts_mode bug fix - CICE_DECOMPTYPE overwritten

### DIFF
--- a/cime_config/buildcpp
+++ b/cime_config/buildcpp
@@ -17,7 +17,6 @@ from CIME.utils import run_cmd_no_fail, expect
 from CIME.utils import run_cmd
 from CIME.case import Case
 from CIME.buildnml import parse_input
-
 import glob, shutil
 logger = logging.getLogger(__name__)
 
@@ -93,8 +92,8 @@ def buildcpp(case):
     elif "cice4" in cice_config_opts:
         phys = "cice4"
 
-    if cice_mode == 'prescribed':
-         case.set_value("CICE_DECOMPTYPE", "roundrobin")
+    if cice_mode == 'prescribed' and not pts_mode:
+        case.set_value("CICE_DECOMPTYPE", "roundrobin")
 
     if cice_mode == 'prescribed':
         ntr_aero = 0
@@ -184,7 +183,6 @@ def buildcpp(case):
 
     # update the xml variable CICE_CPPDEFS with the above definition
     case.set_value("CICE_CPPDEFS", cice_cppdefs)
-    case.flush()
 
     return cice_cppdefs
 

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -25,7 +25,7 @@ def _build_cice():
 
         # call buildcpp  to set the cppdefs
         cmd = os.path.join(os.path.join(srcroot,"components","cice","cime_config","buildcpp"))
-        logger.info("     ...calling cice buildcpp to set build time options")
+        logger.info("     ... buildlib calling cice buildcpp to set build time options")
         try:
             mod = imp.load_source("buildcpp", cmd)
             cice_cppdefs = mod.buildcpp(case)
@@ -44,7 +44,7 @@ def _build_cice():
         if not os.path.isfile(filepath_file):
             srcroot = case.get_value("SRCROOT")
             caseroot = case.get_value("CASEROOT")
-            paths = [os.path.join(caseroot,"SourceMods","src.cice"), 
+            paths = [os.path.join(caseroot,"SourceMods","src.cice"),
                      os.path.join(srcroot,"components","cice","src","drivers","cesm"),
                      os.path.join(srcroot,"components","cice","src","io_pio"),
                      os.path.join(srcroot,"components","cice","src","mpi"),

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""CICE namelist creator 
+"""CICE namelist creator
 """
 
 # Typically ignore this.
@@ -85,8 +85,8 @@ def _create_namelists(case, confdir, infile, nmlgen):
     if "DTRLVL=0" in case.get_value("CICE_CPPDEFS"):
         config['ntrlvl'] = "0"
 
-    # Note - xml ICE_NCAT, CICE_DECOMPSETTING, CICE_DECOMPTYPE are used 
-    # in setting the cice namelist and are set in buildlib: 
+    # Note - xml ICE_NCAT, CICE_DECOMPSETTING, CICE_DECOMPTYPE are used
+    # in setting the cice namelist and are set in buildlib:
 
     #----------------------------------------------------
     # Initialize namelist defaults
@@ -107,7 +107,7 @@ def _create_namelists(case, confdir, infile, nmlgen):
         processor_shape = case.get_value("CICE_DECOMPSETTING")
     nmlgen.set_value('processor_shape', value=processor_shape)
 
-    # set initial conditions for branch of hybrid runs 
+    # set initial conditions for branch of hybrid runs
     # TODO - need to implement multi-instance for these files - the following assumes single instance
     run_type = case.get_value("RUN_TYPE")
     if run_type == 'branch' or run_type == 'hybrid':
@@ -116,7 +116,7 @@ def _create_namelists(case, confdir, infile, nmlgen):
         run_tod     = case.get_value("RUN_REFTOD")
         ice_ic = "%s.cice.r.%s-%s.nc" %(run_refcase, run_refdate, run_tod)
         nmlgen.add_default("ice_ic", value=ice_ic, ignore_abs_path=True)
-    else: 
+    else:
         nmlgen.add_default("ice_ic")
         if nmlgen.get_value('ice_ic') == 'UNSET':
             nmlgen.set_value('ice_ic', value="default")
@@ -171,26 +171,26 @@ def buildnml(case, caseroot, compname):
 ###############################################################################
     """Build the cice namelist """
 
-    # Build the component namelist 
+    # Build the component namelist
     if compname != "cice":
         raise AttributeError
 
-    srcroot = case.get_value("SRCROOT") 
+    srcroot = case.get_value("SRCROOT")
     rundir = case.get_value("RUNDIR")
     ninst = case.get_value("NINST_ICE")
 
-    # call buildcpp to obtain cppdefs 
+    # call buildcpp to obtain cppdefs
     call_buildcpp = False
     if not os.path.exists(os.path.join(caseroot,"LockedFiles","env_build.xml")):
         call_buildcpp = True
     else:
-        file1 = os.path.join(caseroot,"env_build.xml")  
+        file1 = os.path.join(caseroot,"env_build.xml")
         file2 = os.path.join(caseroot,"LockedFiles","env_build.xml")
         if not filecmp.cmp(file1, file2):
             call_buildcpp = True
     if call_buildcpp:
         cmd = os.path.join(os.path.join(srcroot,"components","cice","cime_config","buildcpp"))
-        logger.info("     ...calling cice buildcpp to set build time options")
+        logger.info("     ...buildnml calling cice buildcpp to set build time options")
         try:
             mod = imp.load_source("buildcpp", cmd)
             mod.buildcpp(case)
@@ -203,7 +203,7 @@ def buildnml(case, caseroot, compname):
         os.makedirs(confdir)
 
     #----------------------------------------------------
-    # Construct the namelist generator 
+    # Construct the namelist generator
     #----------------------------------------------------
     # determine directory for user modified namelist_definitions.xml and namelist_defaults.xml
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src.cice")
@@ -234,7 +234,7 @@ def buildnml(case, caseroot, compname):
 
         # If multi-instance case does not have restart file, use
         # single-case restart for each instance
-        rpointer = "rpointer.ice" 
+        rpointer = "rpointer.ice"
         if (os.path.isfile(os.path.join(rundir,rpointer)) and
             (not os.path.isfile(os.path.join(rundir,rpointer + inst_string)))):
             shutil.copy(os.path.join(rundir, rpointer),
@@ -252,7 +252,7 @@ def buildnml(case, caseroot, compname):
         create_namelist_infile(case, user_nl_file, infile)
         namelist_infile = [infile]
 
-        # create namelist 
+        # create namelist
         _create_namelists(case, confdir, namelist_infile, nmlgen)
 
         # copy namelist files to rundir

--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -1,4 +1,13 @@
 ===============================================================
+cice5_20190204
+Originator: jedwards
+Date:  04 Feb 2019
+Version: 5.0
+One-line: Fix bug in setting DECOMPTYPE for pts_mode
+
+        modified: buildcpp, buildnml, buildlib
+
+===============================================================
 cice5_20190107
 Originator: jedwards
 Date:  07 Jan 2019
@@ -68,7 +77,7 @@ Date:  13 Sep 2018
 Version: 5.0
 One-line: Fix hobart NAG and CMIP variable changes.
 
-I changed the nodes for the hobart tests to 4 so the 
+I changed the nodes for the hobart tests to 4 so the
 NAG compiler tests would pass.
 I also made some updates for CMIP variables. (BFB)
 
@@ -187,7 +196,7 @@ cice5_20180213
 Originator: dbailey
 Date: 13 Feb 2018
 Version: 5.0
-One-line: 
+One-line:
 
         modified:   cime_config/testdefs/testlist_cice.xml
 


### PR DESCRIPTION
tested with /SMS_D_Ln9.T42_T42.FSCAM.cheyenne_intel.cam-scam_mpace_outfrq9s

The issue was that in pts_mode buildcpp would change the CICE_DECOMPTYPE twice and 
leave it in the wrong state. 