### PR TITLE
answer changes due to namelist changes 

### DIFF
--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -1712,18 +1712,18 @@
   <!--   </values> -->
   <!-- </entry> -->
 
-  <!-- <entry id="ustar_min"> -->
-  <!--   <type>real</type> -->
-  <!--   <category>forcing</category> -->
-  <!--   <group>forcing_nml</group> -->
-  <!--   <desc> -->
-  <!--     minimum value of ocean friction velocity -->
-  <!--   </desc> -->
-  <!--   <values> -->
-  <!--     <value>0.005</value> -->
-  <!--     <value hgrid ='tx0.25v1'>0.0005</value> -->
-  <!--   </values> -->
-  <!-- </entry> -->
+  <entry id="ustar_min">
+    <type>real</type>
+    <category>forcing</category>
+    <group>forcing_nml</group>
+    <desc>
+      minimum value of ocean friction velocity
+    </desc>
+    <values>
+      <value>0.005</value>
+      <value hgrid ='tx0.25v1'>0.0005</value>
+    </values>
+  </entry>
 
   <!-- <entry id="oceanmixed_ice"> -->
   <!--   <type>logical</type> -->


### PR DESCRIPTION
This accompanies the mvetens/nuopc_cap_pr1 and results in roundoff level changes.
The new baselines are in /glade/p/cesmdata/cseg/cesm_baselines/aux_cice_cesm2_2_alpha03a_cimemaster2/.