### PR TITLE
fixed reference to shr_kind_r8

### DIFF
--- a/src/source/ice_atmo.F90
+++ b/src/source/ice_atmo.F90
@@ -377,7 +377,7 @@
       !------------------------------------------------------------
       ! iterate to converge on Z/L, ustar, tstar and qstar
       !------------------------------------------------------------
-      ustar_prev = 2.0_SHR_KIND_R8 * ustar
+      ustar_prev = 2.0_dbl_kind * ustar
       do iter =1,flux_convergence_max_iteration
          do ij = 1, icells
             i = indxi(ij)


### PR DESCRIPTION
src/source/ice_atmo.F90 was referencing shr_kind_r8 rather than dbl_kind. This PR is a one line change that fixes this. This needs to be accepted as soon as possible since it is required for a CMEPS update.