### PR TITLE
fix referencing shr_kind_in

### DIFF
--- a/src/drivers/nuopc/ice_prescribed_mod.F90
+++ b/src/drivers/nuopc/ice_prescribed_mod.F90
@@ -46,7 +46,7 @@ module ice_prescribed_mod
   ! !PUBLIC DATA MEMBERS:
   logical(kind=log_kind), public :: prescribed_ice      ! true if prescribed ice
 
-  integer(SHR_KIND_IN),parameter :: nFilesMaximum = 400 ! max number of files
+  integer(kind=int_kind),parameter :: nFilesMaximum = 400 ! max number of files
   integer(kind=int_kind)         :: stream_year_first   ! first year in stream to use
   integer(kind=int_kind)         :: stream_year_last    ! last year in stream to use
   integer(kind=int_kind)         :: model_year_align    ! align stream_year_first


### PR DESCRIPTION
src/drivers/nuopc/ice_prescribed_mod.F90 was referencing shr_kind_in rather than int_kind. This PR is a one line change that fixes this. This needs to be accepted as soon as possible since it is required for a CMEPS update. I'm not sure why my previous testing did not catch this.