### PR TITLE
Another fix referencing shr_kind_in

### DIFF
--- a/src/drivers/mct/ice_prescribed_mod.F90
+++ b/src/drivers/mct/ice_prescribed_mod.F90
@@ -68,7 +68,7 @@ module ice_prescribed_mod
 
 !EOP
 
-   integer(SHR_KIND_IN),parameter :: nFilesMaximum = 400 ! max number of files
+   integer(kind=int_kind),parameter :: nFilesMaximum = 400 ! max number of files
    integer(kind=int_kind)         :: stream_year_first   ! first year in stream to use
    integer(kind=int_kind)         :: stream_year_last    ! last year in stream to use
    integer(kind=int_kind)         :: model_year_align    ! align stream_year_first


### PR DESCRIPTION
src/drivers/mct/ice_prescribed_mod.F90 was referencing shr_kind_in rather than int_kind. This PR is a one line change that fixes this.  This needs to be accepted to fix CESM testing.  Will also need a new
cice tag in the very near future.