### PR TITLE
Add cice4 option to component definition

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -5,9 +5,10 @@
 <entry_id version="3.0">
 
   <description>
-    <desc ice="CICE[%PRES][%CMIP6]">Sea ICE (cice) model version 5</desc>
+    <desc ice="CICE[%PRES][%CMIP6][%CICE4]">Sea ICE (cice) model version 5</desc>
     <desc option="PRES" > :prescribed cice</desc>
     <desc option="CMIP6"> :with modifications appropriate for CMIP6 experiments</desc>
+    <desc option="CICE4"> :running with cice4 physics</desc>
   </description>
 
   <entry id="COMP_ICE">
@@ -34,8 +35,9 @@
   <entry id="CICE_CONFIG_OPTS">
     <type>char</type>
     <default_value></default_value>
-    <values>
+    <values match="last">
       <value compset="_CICE[_%]"> -phys cice5 </value>
+      <value compset="_CICE%[^_]*CICE4"> -phys cice4 </value>
     </values>
     <group>build_component_cice</group>
     <file>env_build.xml</file>


### PR DESCRIPTION
compsets with `CICE%CICE4` will get `-phys cice4` instead of `-phys cice5` in
`CICE_CONFIG_OPTS`. I did not add any compsets in CICE that use this, but will
update POP to use CICE4 in the `GIAF_JRA_HR` compset to match prior experiments
(which relied on `xmlchange` to change the physics).

Fixes #29 