### PR TITLE
import_export can force fields to be non-negative

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -121,6 +121,16 @@ def _create_namelists(case, confdir, infile, nmlgen):
         if nmlgen.get_value('ice_ic') == 'UNSET':
             nmlgen.set_value('ice_ic', value="default")
 
+    # patch maps are not positive definite, aavg and blin are
+    if case.get_value("ATM2OCN_FMAPNAME").find('patc') == -1:
+      nmlgen.add_default("atm2ice_fmap_is_pos_def", value=".true.")
+    else:
+      nmlgen.add_default("atm2ice_fmap_is_pos_def", value=".false.")
+    if case.get_value("ATM2OCN_SMAPNAME").find('patc') == -1:
+      nmlgen.add_default("atm2ice_smap_is_pos_def", value=".true.")
+    else:
+      nmlgen.add_default("atm2ice_smap_is_pos_def", value=".false.")
+
     # error checks for prescribed ice mode
     if cice_mode == 'prescribed':
         sstice_grid_filename = case.get_value('SSTICE_GRID_FILENAME')

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -85,6 +85,12 @@ def _create_namelists(case, confdir, infile, nmlgen):
     if "DTRLVL=0" in case.get_value("CICE_CPPDEFS"):
         config['ntrlvl'] = "0"
 
+    if case.get_value("ATM2OCN_FMAPNAME").find('patc') != -1:
+        config['fmaptype'] = 'patch'
+
+    if case.get_value("ATM2OCN_SMAPNAME").find('patc') != -1:
+        config['smaptype'] = 'patch'
+
     # Note - xml ICE_NCAT, CICE_DECOMPSETTING, CICE_DECOMPTYPE are used
     # in setting the cice namelist and are set in buildlib:
 
@@ -120,16 +126,6 @@ def _create_namelists(case, confdir, infile, nmlgen):
         nmlgen.add_default("ice_ic", ignore_abs_path=True)
         if nmlgen.get_value('ice_ic') == 'UNSET':
             nmlgen.set_value('ice_ic', value="default")
-
-    # patch maps are not positive definite, aavg and blin are
-    if case.get_value("ATM2OCN_FMAPNAME").find('patc') == -1:
-      nmlgen.add_default("atm2ice_fmap_is_pos_def", value=".true.")
-    else:
-      nmlgen.add_default("atm2ice_fmap_is_pos_def", value=".false.")
-    if case.get_value("ATM2OCN_SMAPNAME").find('patc') == -1:
-      nmlgen.add_default("atm2ice_smap_is_pos_def", value=".true.")
-    else:
-      nmlgen.add_default("atm2ice_smap_is_pos_def", value=".false.")
 
     # error checks for prescribed ice mode
     if cice_mode == 'prescribed':

--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -180,6 +180,32 @@
     </values>
   </entry>
 
+  <entry id="atm2ice_fmap_is_pos_def" skip_default_entry="true">
+    <type>logical</type>
+    <category>setup</category>
+    <group>setup_nml</group>
+    <desc>
+      Is atm2ice_fmap positive definite? If not, need to account for possible
+      negative values in ice_import_export.F90
+    </desc>
+    <values>
+      <value>.true.</value>
+    </values>
+  </entry>
+
+  <entry id="atm2ice_smap_is_pos_def" skip_default_entry="true">
+    <type>logical</type>
+    <category>setup</category>
+    <group>setup_nml</group>
+    <desc>
+      Is atm2ice_smap positive definite? If not, need to account for possible
+      negative values in ice_import_export.F90
+    </desc>
+    <values>
+      <value>.true.</value>
+    </values>
+  </entry>
+
   <!-- <entry id="runtype" modify_via_xml="RUN_TYPE"> -->
   <!--   <type>char</type> -->
   <!--   <category>setup</category> -->

--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -180,7 +180,7 @@
     </values>
   </entry>
 
-  <entry id="atm2ice_fmap_is_pos_def" skip_default_entry="true">
+  <entry id="atm2ice_fmap_is_pos_def">
     <type>logical</type>
     <category>setup</category>
     <group>setup_nml</group>
@@ -190,10 +190,11 @@
     </desc>
     <values>
       <value>.true.</value>
+      <value fmaptype="patch">.false.</value>
     </values>
   </entry>
 
-  <entry id="atm2ice_smap_is_pos_def" skip_default_entry="true">
+  <entry id="atm2ice_smap_is_pos_def">
     <type>logical</type>
     <category>setup</category>
     <group>setup_nml</group>
@@ -203,6 +204,7 @@
     </desc>
     <values>
       <value>.true.</value>
+      <value smaptype="patch">.false.</value>
     </values>
   </entry>
 

--- a/src/drivers/mct/ice_import_export.F90
+++ b/src/drivers/mct/ice_import_export.F90
@@ -21,6 +21,7 @@ module ice_import_export
   use ice_flux        , only: fiso_atm, fiso_ocn, fiso_rain, fiso_evap, &
                               Qa_iso, Qref_iso, HDO_ocn, H2_18O_ocn, H2_16O_ocn
   use ice_flux        , only: send_i2x_per_cat, fswthrun_ai
+  use ice_init        , only: atm2ice_fmap_is_pos_def, atm2ice_smap_is_pos_def
   use ice_ocean       , only: tfrz_option
   use ice_atmo        , only: Cdn_atm
   use ice_state       , only: vice, vsno, aice, aicen_init, trcr
@@ -154,6 +155,19 @@ contains
        enddo    !j
     enddo        !iblk
     !$OMP END PARALLEL DO
+
+    if (.not. atm2ice_smap_is_pos_def) then
+      Qa   = max(Qa  , c0)
+      rhoa = max(rhoa, c0)
+    end if
+    if (.not. atm2ice_fmap_is_pos_def) then
+      swvdr = max(swvdr, c0)
+      swidr = max(swidr, c0)
+      swvdf = max(swvdf, c0)
+      swidf = max(swidf, c0)
+      frain = max(frain, c0)
+      fsnow = max(fsnow, c0)
+    end if
 
     if (rasm_snowrain_split) then
        !$OMP PARALLEL DO PRIVATE(iblk,i,j)

--- a/src/source/ice_init.F90
+++ b/src/source/ice_init.F90
@@ -23,6 +23,7 @@
                      ! 'default'  => latitude and sst dependent
                      ! 'none'     => no ice
                      ! note:  restart = .true. overwrites
+      logical :: atm2ice_fmap_is_pos_def, atm2ice_smap_is_pos_def
 
 !=======================================================================
 
@@ -124,7 +125,8 @@
         print_global,   print_points,   latpnt,          lonpnt,        &
         dbug,           histfreq,       histfreq_n,      hist_avg,      &
         history_dir,    history_file,                                   &
-        write_ic,       incond_dir,     incond_file, history_precision
+        write_ic,       incond_dir,     incond_file, history_precision, &
+        atm2ice_fmap_is_pos_def, atm2ice_smap_is_pos_def
 
       namelist /grid_nml/ &
         grid_format,    grid_type,       grid_file,     kmt_file,       &
@@ -216,6 +218,8 @@
       lcdf64       = .false. ! 64 bit offset for netCDF
       history_precision = 4    ! write history files in single precision
       ice_ic       = 'default'      ! latitude and sst-dependent
+      atm2ice_fmap_is_pos_def = .true.
+      atm2ice_smap_is_pos_def = .true.
       grid_format  = 'bin'          ! file format ('bin'=binary or 'nc'=netcdf)
       grid_type    = 'rectangular'  ! define rectangular grid internally
       grid_file    = 'unknown_grid_file'
@@ -714,6 +718,8 @@
       call broadcast_scalar(lcdf64,             master_task)
       call broadcast_scalar(pointer_file,       master_task)
       call broadcast_scalar(ice_ic,             master_task)
+      call broadcast_scalar(atm2ice_fmap_is_pos_def,  master_task)
+      call broadcast_scalar(atm2ice_smap_is_pos_def,  master_task)
       call broadcast_scalar(grid_format,        master_task)
       call broadcast_scalar(grid_type,          master_task)
       call broadcast_scalar(grid_file,          master_task)
@@ -887,6 +893,10 @@
          write(nu_diag,*)    ' use_restart_time          = ', use_restart_time
          write(nu_diag,*)    ' ice_ic                    = ', &
                                trim(ice_ic)
+         write(nu_diag,*)    ' atm2ice_fmap_is_pos_def   = ', &
+                               atm2ice_fmap_is_pos_def
+         write(nu_diag,*)    ' atm2ice_smap_is_pos_def   = ', &
+                               atm2ice_smap_is_pos_def
          write(nu_diag,*)    ' grid_type                 = ', &
                                trim(grid_type)
          if (trim(grid_type) /= 'rectangular' .or. &


### PR DESCRIPTION
If the atm -> ice scalar map is not positive definite, then ensure Qa and rhoa
are non-negative by setting all negative values to 0. Similarly, if the atm ->
ice flux map is not positive definite, ensure swvdr, swidr, swvdf, swidf,
frain, and fsnow are all non-negative.

The implementation is a little kludgy: component models in CESM do not have
access to public data in the coupler (otherwise this introduces circular
dependencies), so we can't just query the driver to find out about the map.
Instead, I introduce two new namelist variables in &setup_nml and buildnml sets
them based on the ATM2OCN map names in env_run.xml. Currently, the logic is "if
'patc' shows up in the file name, it's a patch map and therefore not positive
definite. Otherwise it's a positive definite map."

Fixes #28 


****

### Testing

I ran `aux_cice` with the current `master` branch to generate baselines. For these baselines, four tests failed:

```
4	FAIL
	1	COMPARE (FAIL)
      1 ERP.f19_g17_rx1.DTEST.cheyenne_intel.cice-default
	3	CREATE_NEWCASE (FAIL)
      1 ERS_Ld5.f19_g17.ETEST.cheyenne_intel.cice-default
      1 ERS_Ld5.T62_t061.DTEST.cheyenne_intel.cice-default
      1 ERS_Ld7.f19_g17.B1850.cheyenne_intel.cice-pop
```

My sandbox did not have CAM available, so that explains the `ETEST` and `B1850` failures. The `T62_t061` test failed with `ERROR: No variable grid found in case` in the `TestStatus.log`. The `ERP` test is showing the following in `cice.h.0001-01-11.nc.base.cprnc.out`

```
SUMMARY of cprnc:
 A total number of    116 fields were compared
          of which      0 had non-zero differences
               and     14 had differences in fill patterns
               and      0 had different dimension sizes
 A total number of      0 fields could not be analyzed
 A total number of      0 fields on file 1 were not found on file2.
  diff_test: the two files seem to be DIFFERENT
```

and similarly in `cpl.hi.0001-01-12-00000.nc.base.cprnc.out`

```
SUMMARY of cprnc:
 A total number of    319 fields were compared
          of which      0 had non-zero differences
               and     49 had differences in fill patterns
               and      0 had different dimension sizes
 A total number of      0 fields could not be analyzed
 A total number of      0 fields on file 1 were not found on file2.
  diff_test: the two files seem to be DIFFERENT
```

Again, that was just from generating a baseline. When comparing my branch, I get the same four failures (for the same reason). Nine tests run to completion, and all of them fail `NLCOMP` due to the addition of two new namelist variables, but the important comparison is

```
113	PASS
	9	BASELINE (PASS)
      1 ERI.f19_g17_rx1.G.cheyenne_intel.pop-cice
      1 ERI.T62_g17.DTEST.cheyenne_intel.cice-default
      1 ERP.f19_g17_rx1.DTEST.cheyenne_intel.cice-default
      1 ERS_D_Ld5.T62_g17.DTEST.cheyenne_intel.cice-default
      1 ERS.f19_g17_rx1.G1850ECO.cheyenne_intel.pop-cice
      1 ERS_Ld5.T62_s11.DTEST.cheyenne_intel.cice-default
      1 ERS_Lm3.T62_g37.G.cheyenne_intel.pop-cice
      1 PET.f19_g17_rx1.G.cheyenne_intel.pop-cice
      1 PET_Ld2.T62_g17.DTEST.cheyenne_intel.cice-default
```

Namely, the nine tests that run to completion are bit-for-bit identical with the previous CICE `master` branch.

I also verified that a `SMS_Ld1.TL319_t13.GIAF_JRA_HR.cheyenne_intel.pop-performance_eval` failed on the current `master` with `ERROR: ice: Vertical thermo error` but successfully complete with this branch.

****

### Final note

As mentioned above, this is a somewhat kludgy implementation. I'm happy to update this PR with a cleaner implementation if someone can come up with a better way of doing things... but given the limitation that CICE can't access the mapping data in the driver once the model is running, this seemed like the only option.