### PR TITLE
bug fix when multiple ice categories are sent

### DIFF
--- a/src/drivers/nuopc/ice_import_export.F90
+++ b/src/drivers/nuopc/ice_import_export.F90
@@ -1011,7 +1011,7 @@ contains
           ! penetrative shortwave by category
           ! Note: no need zero out pass-through fields over land for benefit of x2oacc fields in cpl hist files since
           ! the export state has been zeroed out at the beginning
-          call state_setexport(exportState, 'mean_sw_pen_to_ocn_ifrac_n', input=aicen_init, index=n, &
+          call state_setexport(exportState, 'mean_sw_pen_to_ocn_ifrac_n', input=fswthrun_ai, index=n, &
                lmask=tmask, ifrac=ailohi, ungridded_index=n, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end do


### PR DESCRIPTION
This is needed to have all compsets that have POP using mcog work.